### PR TITLE
Add strategy templates

### DIFF
--- a/bin/template.ts
+++ b/bin/template.ts
@@ -40,7 +40,7 @@ const categoryMap = {
     'library/shadcn-ui': 'Shadcn UI',
     'library/shiki': 'Shiki',
     'library/tailwind-css': 'Tailwind CSS',
-    'use-case/ecommerce': 'E-commerce',
+    'use-case/e-commerce': 'E-commerce',
     'use-case/experiment': 'Experiment',
     'use-case/saas': 'SaaS',
 };

--- a/templates/croct/experience/e-commerce/cart/README.md
+++ b/templates/croct/experience/e-commerce/cart/README.md
@@ -1,0 +1,27 @@
+# Introduction
+
+This template defines a personalized experience for e-commerce visitors based on their [shopping cart](https://docs.croct.com/reference/cql/data-types/shopping?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=cart) total.
+
+It can be used to encourage higher-order values by highlighting incentives such as free shipping after certain thresholds.
+
+## What's included
+
+This experience includes:
+
+- **Components:** banner image, CTA, announcement bar, and carousel section
+- **Slots:** announcement bar and carousel section
+- **Audience:** `cart's total is less than 150`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=cart), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It supports, for instance, other comparisons like [greater than](https://docs.croct.com/reference/cql/expressions/tests/comparison#greater-than) or [between](https://docs.croct.com/reference/cql/expressions/tests/comparison#between).
+
+> 💬 Event tracking
+>
+> Personalization with the `cart` variable requires tracking [e-commerce events](https://docs.croct.com/reference/event/overview?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=cart#e-commerce-events) in advance.
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/e-commerce/cart
+```

--- a/templates/croct/experience/e-commerce/cart/configuration/announcement-bar-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/cart/configuration/announcement-bar-experience-content.en.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "text": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Free shipping for orders over $150"
+      }
+    },
+    "style": {
+      "type": "structure",
+      "attributes": {
+        "textColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#ffffff"
+          }
+        },
+        "backgroundColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#000000"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/cart/configuration/announcement-bar-schema.json
+++ b/templates/croct/experience/e-commerce/cart/configuration/announcement-bar-schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Announcement bar",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The link to navigate by clicking on the top bar."
+    },
+    "text": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Message",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The message to display in the top bar."
+    },
+    "style": {
+      "type": {
+        "type": "structure",
+        "attributes": {
+          "textColor": {
+            "type": {
+              "type": "text",
+              "format": "color"
+            },
+            "label": "Text Color",
+            "private": false,
+            "optional": false,
+            "position": 1,
+            "description": "The text color of the top bar."
+          },
+          "backgroundColor": {
+            "type": {
+              "type": "text",
+              "format": "color"
+            },
+            "label": "Background Color",
+            "private": false,
+            "optional": false,
+            "position": 0,
+            "description": "The background color of the top bar."
+          }
+        }
+      },
+      "label": "Style",
+      "position": 2,
+      "description": "The style of the top bar."
+    }
+  },
+  "description": "A small text bar featured at the top of a page."
+}

--- a/templates/croct/experience/e-commerce/cart/configuration/announcement-bar-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/cart/configuration/announcement-bar-slot-content.en.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://example.com/sale"
+      }
+    },
+    "text": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Online only: up to 70% off!"
+      }
+    },
+    "style": {
+      "type": "structure",
+      "attributes": {
+        "textColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#ffffff"
+          }
+        },
+        "backgroundColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#000000"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/cart/configuration/banner-image-schema.json
+++ b/templates/croct/experience/e-commerce/cart/configuration/banner-image-schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": true,
+      "position": 1
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {
+          "maximumSize": 307200
+        }
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 0
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/cart/configuration/carousel-section-schema.json
+++ b/templates/croct/experience/e-commerce/cart/configuration/carousel-section-schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Carousel section",
+  "attributes": {
+    "banners": {
+      "type": {
+        "type": "list",
+        "items": {
+          "id": "banner-image",
+          "type": "reference"
+        },
+        "itemLabel": "Banner"
+      },
+      "label": "Banners",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "autoplay": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Autoplay",
+      "private": false,
+      "optional": true,
+      "position": 3
+    },
+    "headline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Title",
+      "private": false,
+      "optional": true,
+      "position": 0,
+      "description": "The title displayed at the top of the section."
+    },
+    "description": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Description",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The description displayed bellow the title."
+    },
+    "pauseOnHover": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Pause on hover",
+      "private": false,
+      "optional": true,
+      "position": 4
+    }
+  },
+  "description": "A section of ordered banners."
+}

--- a/templates/croct/experience/e-commerce/cart/configuration/home-carousel-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/cart/configuration/home-carousel-experience-content.en.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/c1b9e756-9490-4c6a-acc8-e6194ebc2752"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/cart/configuration/home-carousel-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/cart/configuration/home-carousel-slot-content.en.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/b4cb19af-70ba-4fc9-a83e-e213b1fc7150"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/01462ecd-9323-4fa4-bba8-5d9affac996c"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/2edf720a-abd6-40b2-bf27-9f98eb59acab"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/cart/cover.png
+++ b/templates/croct/experience/e-commerce/cart/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:35993b0916eeaa1af29cbf06a26796be433db12121281678ab61114acf6466d7
+size 47053

--- a/templates/croct/experience/e-commerce/cart/template.json5
+++ b/templates/croct/experience/e-commerce/cart/template.json5
@@ -1,0 +1,93 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Cart-based experience",
+  "description": "A personalized experience based on the total amount of the shopping cart.",
+  "metadata": {
+    "id": "use-case/e-commerce/cart",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=cart"
+    },
+    "categories": [
+      "use-case/e-commerce"
+    ],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/cart/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/cart/cover.png",
+    "installationUrl": "croct://use-case/e-commerce/cart",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/cart/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "cart-with-less-than-150": {
+            "name": "Cart with less than $150",
+            "criteria": "cart's total is less than 150"
+          }
+        },
+        "components": {
+          "banner-image": {
+            "name": "Banner image",
+            "schema": "${import('./configuration/banner-image-schema.json')}"
+          },
+          "carousel-section": {
+            "name": "Carousel section",
+            "description": "A section of ordered banners.",
+            "schema": "${import('./configuration/carousel-section-schema.json')}"
+          },
+          "announcement-bar": {
+            "name": "Announcement bar",
+            "description": "A small text bar featured at the top of a page.",
+            "schema": "${import('./configuration/announcement-bar-schema.json')}"
+          }
+        },
+        "slots": {
+          "announcement-bar": {
+            "name": "Announcement bar",
+            "component": "announcement-bar",
+            "content": {
+              "en": "${import('./configuration/announcement-bar-slot-content.en.json')}"
+            }
+          },
+          "home-carousel": {
+            "name": "Home carousel",
+            "component": "carousel-section",
+            "content": {
+              "en": "${import('./configuration/home-carousel-slot-content.en.json')}"
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "🚚 Free shipping",
+            "draft": true,
+            "audiences": [
+              "cart-with-less-than-150"
+            ],
+            "slots": [
+              "announcement-bar",
+              "home-carousel"
+            ],
+            "content": {
+              "default": {
+                "announcement-bar": {
+                  "en": "${import('./configuration/announcement-bar-experience-content.en.json')}"
+                },
+                "home-carousel": {
+                  "en": "${import('./configuration/home-carousel-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experience/e-commerce/instagram-campaign/README.md
+++ b/templates/croct/experience/e-commerce/instagram-campaign/README.md
@@ -1,0 +1,23 @@
+# Introduction
+
+This template defines a personalized experience for e-commerce visitors coming from Instagram paid campaigns.
+
+It leverages [UTM parameters](https://docs.croct.com/reference/cql/data-types/marketing?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=instagram_campaign) from ad URLs to align onsite content with the visitor’s interests, creating a seamless and consistent journey from ad to landing page and beyond.
+
+## What's included
+
+This experience includes:
+
+- **Components:** banner image, CTA, navbar, and carousel section
+- **Slots:** navbar, carousel section, and section with featured products
+- **Audience:** `campaign's source is "instagram" and campaign's content matches "shoes"`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=instagram_campaign), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It allows, for instance, to add two or more campaigns to the same audience using [or](https://docs.croct.com/reference/cql/expressions/operations/logical#or), [and](https://docs.croct.com/reference/cql/expressions/operations/logical#and), [starts with](https://docs.croct.com/reference/cql/expressions/tests/string#starts-with), [ends with](https://docs.croct.com/reference/cql/expressions/tests/string#ends-with), or [matches](https://docs.croct.com/reference/cql/expressions/tests/string#matches).
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/e-commerce/instagram-campaign
+```

--- a/templates/croct/experience/e-commerce/instagram-campaign/configuration/banner-image-schema.json
+++ b/templates/croct/experience/e-commerce/instagram-campaign/configuration/banner-image-schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": true,
+      "position": 1
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {
+          "maximumSize": 307200
+        }
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 0
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/instagram-campaign/configuration/carousel-section-schema.json
+++ b/templates/croct/experience/e-commerce/instagram-campaign/configuration/carousel-section-schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Carousel section",
+  "attributes": {
+    "banners": {
+      "type": {
+        "type": "list",
+        "items": {
+          "id": "banner-image",
+          "type": "reference"
+        },
+        "itemLabel": "Banner"
+      },
+      "label": "Banners",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "autoplay": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Autoplay",
+      "private": false,
+      "optional": true,
+      "position": 3
+    },
+    "headline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Title",
+      "private": false,
+      "optional": true,
+      "position": 0,
+      "description": "The title displayed at the top of the section."
+    },
+    "description": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Description",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The description displayed bellow the title."
+    },
+    "pauseOnHover": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Pause on hover",
+      "private": false,
+      "optional": true,
+      "position": 4
+    }
+  },
+  "description": "A section of ordered banners."
+}

--- a/templates/croct/experience/e-commerce/instagram-campaign/configuration/cta-schema.json
+++ b/templates/croct/experience/e-commerce/instagram-campaign/configuration/cta-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": false,
+      "position": 1
+    },
+    "label": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Label",
+      "private": false,
+      "optional": false,
+      "position": 0
+    },
+    "appearance": {
+      "type": {
+        "type": "text",
+        "choices": {
+          "primary": {
+            "label": "Primary",
+            "default": true,
+            "position": 0
+          },
+          "secondary": {
+            "label": "Secondary",
+            "default": false,
+            "position": 1
+          }
+        }
+      },
+      "label": "Appearance",
+      "private": false,
+      "optional": false,
+      "position": 2
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/instagram-campaign/configuration/home-carousel-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/instagram-campaign/configuration/home-carousel-experience-content.en.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women-shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/281ddaa1-a46c-4d5d-905e-a861e7669fc0"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men-shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/238c3995-ed4f-4d76-8aa1-3183923c3061"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes-sale"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/f09710c0-0658-4304-9fe7-34a484520009"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/instagram-campaign/configuration/home-carousel-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/instagram-campaign/configuration/home-carousel-slot-content.en.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/b4cb19af-70ba-4fc9-a83e-e213b1fc7150"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/01462ecd-9323-4fa4-bba8-5d9affac996c"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/2edf720a-abd6-40b2-bf27-9f98eb59acab"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/instagram-campaign/configuration/home-featured-products-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/instagram-campaign/configuration/home-featured-products-experience-content.en.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/heels"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/4431b32c-9880-4fb7-981c-2ea774b09c73"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/flipflops"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/74b93c52-7574-4335-8ee2-a0a11c4dd646"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sneakers"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/3ea47b55-d16c-41d8-88a4-016c68418eb1"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "headline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Flash sale"
+      }
+    },
+    "description": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Online only: up to 70% off!"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/instagram-campaign/configuration/home-featured-products-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/instagram-campaign/configuration/home-featured-products-slot-content.en.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-shorts"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/75fdbcf6-ae52-428f-b9ce-80d4e3e40ffc"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-glasses"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/8918ccba-6a52-4de4-8cfd-a35750ac355b"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-flipflops"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e172f6af-9069-41db-ac93-5b5eaa7229bd"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "headline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Flash sale"
+      }
+    },
+    "description": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Online only: up to 70% off!"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/instagram-campaign/configuration/navbar-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/instagram-campaign/configuration/navbar-experience-content.en.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "items": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/new-shoes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "New Shoes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women-shoes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Women Shoes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men-shoes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Men Shoes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/clothes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Clothes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/accessories"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Accessories"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Sale"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "primaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/checkout"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Checkout"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "secondaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/login"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Login"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "secondary"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/instagram-campaign/configuration/navbar-schema.json
+++ b/templates/croct/experience/e-commerce/instagram-campaign/configuration/navbar-schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Header menu",
+  "attributes": {
+    "items": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": {
+                "type": "text",
+                "format": "url"
+              },
+              "label": "Link",
+              "private": false,
+              "optional": true,
+              "position": 1,
+              "description": "The target URL of the menu item."
+            },
+            "label": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Label",
+              "private": false,
+              "optional": false,
+              "position": 0,
+              "description": "The label of the menu item."
+            }
+          }
+        },
+        "itemLabel": "Menu item"
+      },
+      "label": "Items",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "primaryCta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Primary call to action",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The primary action button of the menu."
+    },
+    "secondaryCta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Secondary call to action",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The secondary action button of the menu."
+    }
+  },
+  "description": "A section of links and CTAs featured at the top of a page."
+}

--- a/templates/croct/experience/e-commerce/instagram-campaign/configuration/navbar-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/instagram-campaign/configuration/navbar-slot-content.en.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "items": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/new"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "New"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Women"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Men"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Shoes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/accessories"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Accessories"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Sale"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "primaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/checkout"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Checkout"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "secondaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/login"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Login"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "secondary"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/instagram-campaign/cover.png
+++ b/templates/croct/experience/e-commerce/instagram-campaign/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7723e722fba384f5dec3208a62cf75215bbee09d07933ef7642f9578dd7ee8d3
+size 45349

--- a/templates/croct/experience/e-commerce/instagram-campaign/template.json5
+++ b/templates/croct/experience/e-commerce/instagram-campaign/template.json5
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Instagram campaign experience",
+  "description": "A personalized experience based on the Instagram campaign associated with the session.",
+  "metadata": {
+    "id": "use-case/e-commerce/instagram-campaign",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=instagram_campaign"
+    },
+    "categories": ["use-case/e-commerce"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/instagram-campaign/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/instagram-campaign/cover.png",
+    "installationUrl": "croct://use-case/e-commerce/instagram-campaign",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/instagram-campaign/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "shoes-instagram-campaign": {
+            "name": "Shoes  Instagram campaign",
+            "criteria": "campaign's source is \"instagram\" and campaign's content matches \"shoes\""
+          }
+        },
+        "components": {
+          "banner-image": {
+            "name": "Banner image",
+            "schema": "${import('./configuration/banner-image-schema.json')}"
+          },
+          "cta": {
+            "name": "CTA",
+            "description": "A call to action button.",
+            "schema": "${import('./configuration/cta-schema.json')}"
+          },
+          "navbar": {
+            "name": "Navbar",
+            "description": "A section of links and CTAs featured at the top of a page.",
+            "schema": "${import('./configuration/navbar-schema.json')}"
+          },
+          "carousel-section": {
+            "name": "Carousel section",
+            "description": "A section of ordered banners.",
+            "schema": "${import('./configuration/carousel-section-schema.json')}"
+          }
+        },
+        "slots": {
+          "home-carousel": {
+            "name": "Home carousel",
+            "component": "carousel-section",
+            "content": {
+              "en": "${import('./configuration/home-carousel-slot-content.en.json')}"
+            }
+          },
+          "home-featured-products": {
+            "name": "Home featured products",
+            "component": "carousel-section",
+            "content": {
+              "en": "${import('./configuration/home-featured-products-slot-content.en.json')}"
+            }
+          },
+          "navbar": {
+            "name": "Navbar",
+            "component": "navbar",
+            "content": {
+              "en": "${import('./configuration/navbar-slot-content.en.json')}"
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "👠 Shoes Instagram campaign",
+            "draft": true,
+            "audiences": [
+              "shoes-instagram-campaign"
+            ],
+            "slots": [
+              "home-featured-products",
+              "home-carousel",
+              "navbar"
+            ],
+            "content": {
+              "default": {
+                "home-featured-products": {
+                  "en": "${import('./configuration/home-featured-products-experience-content.en.json')}"
+                },
+                "home-carousel": {
+                  "en": "${import('./configuration/home-carousel-experience-content.en.json')}"
+                },
+                "navbar": {
+                  "en": "${import('./configuration/navbar-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experience/e-commerce/interest/README.md
+++ b/templates/croct/experience/e-commerce/interest/README.md
@@ -1,0 +1,21 @@
+# Introduction
+
+This template defines a personalized experience for e-commerce websites that uses data from multiple sources, such as onsite behavior and inferred [interests](https://docs.croct.com/reference/cql/data-types/user#user-interests-prop?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=interest), to deliver tailored recommendations for products, blog posts, and other offerings.
+
+## What's included
+
+This experience includes:
+
+- **Components:** banner image, CTA, testimonials, and carousel section
+- **Slots:** testimonials and carousel section
+- **Audience:** `user's interest includes "shoes"`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=interest), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It allows, for instance, to add two or more interests to the same audience using [or](https://docs.croct.com/reference/cql/expressions/operations/logical#or), [and](https://docs.croct.com/reference/cql/expressions/operations/logical#and), or [these quantifiers](https://docs.croct.com/reference/cql/expressions/quantifiers).
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/e-commerce/interest
+```

--- a/templates/croct/experience/e-commerce/interest/configuration/banner-image-schema.json
+++ b/templates/croct/experience/e-commerce/interest/configuration/banner-image-schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": true,
+      "position": 1
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {
+          "maximumSize": 307200
+        }
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 0
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/interest/configuration/carousel-section-schema.json
+++ b/templates/croct/experience/e-commerce/interest/configuration/carousel-section-schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Carousel section",
+  "attributes": {
+    "banners": {
+      "type": {
+        "type": "list",
+        "items": {
+          "id": "banner-image",
+          "type": "reference"
+        },
+        "itemLabel": "Banner"
+      },
+      "label": "Banners",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "autoplay": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Autoplay",
+      "private": false,
+      "optional": true,
+      "position": 3
+    },
+    "headline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Title",
+      "private": false,
+      "optional": true,
+      "position": 0,
+      "description": "The title displayed at the top of the section."
+    },
+    "description": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Description",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The description displayed bellow the title."
+    },
+    "pauseOnHover": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Pause on hover",
+      "private": false,
+      "optional": true,
+      "position": 4
+    }
+  },
+  "description": "A section of ordered banners."
+}

--- a/templates/croct/experience/e-commerce/interest/configuration/home-carousel-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/interest/configuration/home-carousel-experience-content.en.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women-shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/281ddaa1-a46c-4d5d-905e-a861e7669fc0"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men-shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/238c3995-ed4f-4d76-8aa1-3183923c3061"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes-sale"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/f09710c0-0658-4304-9fe7-34a484520009"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/interest/configuration/home-carousel-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/interest/configuration/home-carousel-slot-content.en.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/b4cb19af-70ba-4fc9-a83e-e213b1fc7150"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/01462ecd-9323-4fa4-bba8-5d9affac996c"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/2edf720a-abd6-40b2-bf27-9f98eb59acab"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/interest/configuration/home-featured-products-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/interest/configuration/home-featured-products-experience-content.en.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/heels"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/4431b32c-9880-4fb7-981c-2ea774b09c73"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/flipflops"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/74b93c52-7574-4335-8ee2-a0a11c4dd646"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sneakers"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/3ea47b55-d16c-41d8-88a4-016c68418eb1"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "headline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Flash sale"
+      }
+    },
+    "description": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Online only: up to 70% off!"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/interest/configuration/home-featured-products-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/interest/configuration/home-featured-products-slot-content.en.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-shorts"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/75fdbcf6-ae52-428f-b9ce-80d4e3e40ffc"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-glasses"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/8918ccba-6a52-4de4-8cfd-a35750ac355b"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-flipflops"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e172f6af-9069-41db-ac93-5b5eaa7229bd"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "headline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Flash sale"
+      }
+    },
+    "description": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Online only: up to 70% off!"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/interest/configuration/testimonials-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/interest/configuration/testimonials-experience-content.en.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why they love us"
+      }
+    },
+    "testimonials": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I bought two sneakers, and I loved it!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "John Doe"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/ef30dcd2-22f3-4477-9d1a-a9291b932521"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Take a look on their dresses, they're amazing. It's perfect!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Carol Duran"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/a53e3215-a76b-48b2-8f1e-2755f052971c"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Their flip flops are so funny! Loved them!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Alex Bobby"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/ff550851-aebd-4838-b1e9-cb5893413220"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/interest/configuration/testimonials-schema.json
+++ b/templates/croct/experience/e-commerce/interest/configuration/testimonials-schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Testimonials",
+  "attributes": {
+    "title": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Title",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The title displayed at the top of the section."
+    },
+    "testimonials": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Logo",
+              "private": false,
+              "optional": true,
+              "position": 3,
+              "description": "The logo of the company the author works for."
+            },
+            "quote": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Quote",
+              "private": false,
+              "optional": false,
+              "position": 0,
+              "description": "The quote or feedback from the customer."
+            },
+            "author": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Author",
+              "private": false,
+              "optional": false,
+              "position": 1,
+              "description": "The name or title of the person providing the testimonial."
+            },
+            "headshot": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Headshot",
+              "private": false,
+              "optional": true,
+              "position": 2,
+              "description": "The headshot of the author of the testimonial."
+            }
+          }
+        },
+        "itemLabel": "Testimonial"
+      },
+      "label": "Testimonials",
+      "private": false,
+      "optional": false,
+      "position": 1
+    }
+  },
+  "description": "A section featuring testimonials."
+}

--- a/templates/croct/experience/e-commerce/interest/configuration/testimonials-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/interest/configuration/testimonials-slot-content.en.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why they love us"
+      }
+    },
+    "testimonials": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I bought several T-shirts, and I loved it!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "John Doe"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/ef30dcd2-22f3-4477-9d1a-a9291b932521"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I'm stunned by the quality of their jeans. It's perfect!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Carol Duran"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/a53e3215-a76b-48b2-8f1e-2755f052971c"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Trust me, this is my favorite place to buy glasses."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Alex Bobby"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/ff550851-aebd-4838-b1e9-cb5893413220"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/interest/cover.png
+++ b/templates/croct/experience/e-commerce/interest/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67d9f95cb05813d7b9d2c22b085ff10642c6de754785d5b672691d32f1342e01
+size 44147

--- a/templates/croct/experience/e-commerce/interest/template.json5
+++ b/templates/croct/experience/e-commerce/interest/template.json5
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Interest-based experience",
+  "description": "A personalized experience based on the user's interests.",
+  "metadata": {
+    "id": "use-case/e-commerce/interest",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=interest"
+    },
+    "categories": ["use-case/e-commerce"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/interest/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/interest/cover.png",
+    "installationUrl": "croct://use-case/e-commerce/interest",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/interest/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "shoes-interest": {
+            "name": "Shoes interest",
+            "criteria": "user's interest includes \"shoes\""
+          }
+        },
+        "components": {
+          "banner-image": {
+            "name": "Banner image",
+            "schema": "${import('./configuration/banner-image-schema.json')}"
+          },
+          "carousel-section": {
+            "name": "Carousel section",
+            "description": "A section of ordered banners.",
+            "schema": "${import('./configuration/carousel-section-schema.json')}"
+          },
+          "testimonials": {
+            "name": "Testimonials",
+            "description": "A section featuring testimonials.",
+            "schema": "${import('./configuration/testimonials-schema.json')}"
+          }
+        },
+        "slots": {
+          "testimonials": {
+            "name": "Testimonials",
+            "component": "testimonials",
+            "content": {
+              "en": "${import('./configuration/testimonials-slot-content.en.json')}"
+            }
+          },
+          "home-carousel": {
+            "name": "Home carousel",
+            "component": "carousel-section",
+            "content": {
+              "en": "${import('./configuration/home-carousel-slot-content.en.json')}"
+            }
+          },
+          "home-featured-products": {
+            "name": "Home featured products",
+            "component": "carousel-section",
+            "content": {
+              "en": "${import('./configuration/home-featured-products-slot-content.en.json')}"
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "👠 Shoes interest",
+            "draft": true,
+            "audiences": [
+              "shoes-interest"
+            ],
+            "slots": [
+              "home-featured-products",
+              "home-carousel",
+              "testimonials"
+            ],
+            "content": {
+              "default": {
+                "home-featured-products": {
+                  "en": "${import('./configuration/home-featured-products-experience-content.en.json')}"
+                },
+                "home-carousel": {
+                  "en": "${import('./configuration/home-carousel-experience-content.en.json')}"
+                },
+                "testimonials": {
+                  "en": "${import('./configuration/testimonials-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experience/e-commerce/landing-page/README.md
+++ b/templates/croct/experience/e-commerce/landing-page/README.md
@@ -1,0 +1,23 @@
+# Introduction
+
+This template defines a personalized experience for e-commerce visitors based on the first page they land on.
+
+By referencing the [session's landing page](https://docs.croct.com/reference/cql/data-types/session?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=landing_page#web-session-landingpage-prop), it’s possible to infer visitor intent and adjust onsite content to create a consistent and relevant experience across the website.
+
+## What's included
+
+This experience includes:
+
+- **Components:** banner image, CTA, testimonials, and carousel section
+- **Slots:** testimonials and carousel section
+- **Audience:** `session's landingPage matches "shoes"`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=landing_page), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It allows, for instance, to add two or more landing pages to the same audience using [or](https://docs.croct.com/reference/cql/expressions/operations/logical#or), [and](https://docs.croct.com/reference/cql/expressions/operations/logical#and), [starts with](https://docs.croct.com/reference/cql/expressions/tests/string#starts-with), [ends with](https://docs.croct.com/reference/cql/expressions/tests/string#ends-with), or [matches](https://docs.croct.com/reference/cql/expressions/tests/string#matches).
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/e-commerce/landing-page
+```

--- a/templates/croct/experience/e-commerce/landing-page/configuration/banner-image-schema.json
+++ b/templates/croct/experience/e-commerce/landing-page/configuration/banner-image-schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": true,
+      "position": 1
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {
+          "maximumSize": 307200
+        }
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 0
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/landing-page/configuration/carousel-section-schema.json
+++ b/templates/croct/experience/e-commerce/landing-page/configuration/carousel-section-schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Carousel section",
+  "attributes": {
+    "banners": {
+      "type": {
+        "type": "list",
+        "items": {
+          "id": "banner-image",
+          "type": "reference"
+        },
+        "itemLabel": "Banner"
+      },
+      "label": "Banners",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "autoplay": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Autoplay",
+      "private": false,
+      "optional": true,
+      "position": 3
+    },
+    "headline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Title",
+      "private": false,
+      "optional": true,
+      "position": 0,
+      "description": "The title displayed at the top of the section."
+    },
+    "description": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Description",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The description displayed bellow the title."
+    },
+    "pauseOnHover": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Pause on hover",
+      "private": false,
+      "optional": true,
+      "position": 4
+    }
+  },
+  "description": "A section of ordered banners."
+}

--- a/templates/croct/experience/e-commerce/landing-page/configuration/home-carousel-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/landing-page/configuration/home-carousel-experience-content.en.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women-shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/281ddaa1-a46c-4d5d-905e-a861e7669fc0"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men-shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/238c3995-ed4f-4d76-8aa1-3183923c3061"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes-sale"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/f09710c0-0658-4304-9fe7-34a484520009"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/landing-page/configuration/home-carousel-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/landing-page/configuration/home-carousel-slot-content.en.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/b4cb19af-70ba-4fc9-a83e-e213b1fc7150"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/01462ecd-9323-4fa4-bba8-5d9affac996c"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/2edf720a-abd6-40b2-bf27-9f98eb59acab"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/landing-page/configuration/home-featured-products-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/landing-page/configuration/home-featured-products-experience-content.en.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/heels"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/4431b32c-9880-4fb7-981c-2ea774b09c73"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/flipflops"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/74b93c52-7574-4335-8ee2-a0a11c4dd646"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sneakers"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/3ea47b55-d16c-41d8-88a4-016c68418eb1"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "headline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Flash sale"
+      }
+    },
+    "description": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Online only: up to 70% off!"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/landing-page/configuration/home-featured-products-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/landing-page/configuration/home-featured-products-slot-content.en.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-shorts"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/75fdbcf6-ae52-428f-b9ce-80d4e3e40ffc"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-glasses"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/8918ccba-6a52-4de4-8cfd-a35750ac355b"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-flipflops"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e172f6af-9069-41db-ac93-5b5eaa7229bd"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "headline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Flash sale"
+      }
+    },
+    "description": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Online only: up to 70% off!"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/landing-page/configuration/testimonials-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/landing-page/configuration/testimonials-experience-content.en.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why they love us"
+      }
+    },
+    "testimonials": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I bought two sneakers, and I loved it!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "John Doe"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/ef30dcd2-22f3-4477-9d1a-a9291b932521"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Take a look on their dresses, they're amazing. It's perfect!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Carol Duran"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/a53e3215-a76b-48b2-8f1e-2755f052971c"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Their flip flops are so funny! Loved them!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Alex Bobby"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/ff550851-aebd-4838-b1e9-cb5893413220"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/landing-page/configuration/testimonials-schema.json
+++ b/templates/croct/experience/e-commerce/landing-page/configuration/testimonials-schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Testimonials",
+  "attributes": {
+    "title": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Title",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The title displayed at the top of the section."
+    },
+    "testimonials": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Logo",
+              "private": false,
+              "optional": true,
+              "position": 3,
+              "description": "The logo of the company the author works for."
+            },
+            "quote": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Quote",
+              "private": false,
+              "optional": false,
+              "position": 0,
+              "description": "The quote or feedback from the customer."
+            },
+            "author": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Author",
+              "private": false,
+              "optional": false,
+              "position": 1,
+              "description": "The name or title of the person providing the testimonial."
+            },
+            "headshot": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Headshot",
+              "private": false,
+              "optional": true,
+              "position": 2,
+              "description": "The headshot of the author of the testimonial."
+            }
+          }
+        },
+        "itemLabel": "Testimonial"
+      },
+      "label": "Testimonials",
+      "private": false,
+      "optional": false,
+      "position": 1
+    }
+  },
+  "description": "A section featuring testimonials."
+}

--- a/templates/croct/experience/e-commerce/landing-page/configuration/testimonials-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/landing-page/configuration/testimonials-slot-content.en.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why they love us"
+      }
+    },
+    "testimonials": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I bought several T-shirts, and I loved it!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "John Doe"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/ef30dcd2-22f3-4477-9d1a-a9291b932521"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I'm stunned by the quality of their jeans. It's perfect!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Carol Duran"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/a53e3215-a76b-48b2-8f1e-2755f052971c"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Trust me, this is my favorite place to buy glasses."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Alex Bobby"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/ff550851-aebd-4838-b1e9-cb5893413220"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/landing-page/cover.png
+++ b/templates/croct/experience/e-commerce/landing-page/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c1f6de508aaca144ebaf85d8be231171ace7636b4e8c4a92c79b4171e0edf74
+size 48543

--- a/templates/croct/experience/e-commerce/landing-page/template.json5
+++ b/templates/croct/experience/e-commerce/landing-page/template.json5
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Landing page-based experience",
+  "description": "A personalized experience based on the session's landing page.",
+  "metadata": {
+    "id": "use-case/e-commerce/landing-page",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=landing_page"
+    },
+    "categories": ["use-case/e-commerce"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/landing-page/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/landing-page/cover.png",
+    "installationUrl": "croct://use-case/e-commerce/landing-page",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/landing-page/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "shoes-landing-page": {
+            "name": "Shoes landing page",
+            "criteria": "session's landingPage matches \"shoes\""
+          }
+        },
+        "components": {
+          "banner-image": {
+            "name": "Banner image",
+            "schema": "${import('./configuration/banner-image-schema.json')}"
+          },
+          "carousel-section": {
+            "name": "Carousel section",
+            "description": "A section of ordered banners.",
+            "schema": "${import('./configuration/carousel-section-schema.json')}"
+          },
+          "testimonials": {
+            "name": "Testimonials",
+            "description": "A section featuring testimonials.",
+            "schema": "${import('./configuration/testimonials-schema.json')}"
+          }
+        },
+        "slots": {
+          "testimonials": {
+            "name": "Testimonials",
+            "component": "testimonials",
+            "content": {
+              "en": "${import('./configuration/testimonials-slot-content.en.json')}"
+            }
+          },
+          "home-carousel": {
+            "name": "Home carousel",
+            "component": "carousel-section",
+            "content": {
+              "en": "${import('./configuration/home-carousel-slot-content.en.json')}"
+            }
+          },
+          "home-featured-products": {
+            "name": "Home featured products",
+            "component": "carousel-section",
+            "content": {
+              "en": "${import('./configuration/home-featured-products-slot-content.en.json')}"
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "👠 Shoes landing page",
+            "draft": true,
+            "audiences": [
+              "shoes-landing-page"
+            ],
+            "slots": [
+              "home-featured-products",
+              "home-carousel",
+              "testimonials"
+            ],
+            "content": {
+              "default": {
+                "home-featured-products": {
+                  "en": "${import('./configuration/home-featured-products-experience-content.en.json')}"
+                },
+                "home-carousel": {
+                  "en": "${import('./configuration/home-carousel-experience-content.en.json')}"
+                },
+                "testimonials": {
+                  "en": "${import('./configuration/testimonials-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experience/e-commerce/location/README.md
+++ b/templates/croct/experience/e-commerce/location/README.md
@@ -1,0 +1,23 @@
+# Introduction
+
+This template defines a personalized experience for e-commerce visitors based on their current location.
+
+By leveraging [geographic information](https://docs.croct.com/reference/cql/data-types/location?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=location), content can be tailored to specific regions while maintaining a consistent navigation experience for visitors outside the targeted areas.
+
+## What's included
+
+This experience includes:
+
+- **Components:** banner image, CTA, announcement bar, and carousel section
+- **Slots:** announcement bar and carousel section
+- **Audience:** `location's city is "New York"`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=location), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It allows, for instance, to add two or more regions to the same audience using [or](https://docs.croct.com/reference/cql/expressions/operations/logical#or), [and](https://docs.croct.com/reference/cql/expressions/operations/logical#and), [is](https://docs.croct.com/reference/cql/expressions/tests/comparison#equal), or [is in](https://docs.croct.com/reference/cql/expressions/tests/collection#in).
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/e-commerce/location
+```

--- a/templates/croct/experience/e-commerce/location/configuration/announcement-bar-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/location/configuration/announcement-bar-experience-content.en.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "text": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Free shipping to New York!"
+      }
+    },
+    "style": {
+      "type": "structure",
+      "attributes": {
+        "textColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#ffffff"
+          }
+        },
+        "backgroundColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#000000"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/location/configuration/announcement-bar-schema.json
+++ b/templates/croct/experience/e-commerce/location/configuration/announcement-bar-schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Announcement bar",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The link to navigate by clicking on the top bar."
+    },
+    "text": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Message",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The message to display in the top bar."
+    },
+    "style": {
+      "type": {
+        "type": "structure",
+        "attributes": {
+          "textColor": {
+            "type": {
+              "type": "text",
+              "format": "color"
+            },
+            "label": "Text Color",
+            "private": false,
+            "optional": false,
+            "position": 1,
+            "description": "The text color of the top bar."
+          },
+          "backgroundColor": {
+            "type": {
+              "type": "text",
+              "format": "color"
+            },
+            "label": "Background Color",
+            "private": false,
+            "optional": false,
+            "position": 0,
+            "description": "The background color of the top bar."
+          }
+        }
+      },
+      "label": "Style",
+      "position": 2,
+      "description": "The style of the top bar."
+    }
+  },
+  "description": "A small text bar featured at the top of a page."
+}

--- a/templates/croct/experience/e-commerce/location/configuration/announcement-bar-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/location/configuration/announcement-bar-slot-content.en.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://example.com/sale"
+      }
+    },
+    "text": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Online only: up to 70% off!"
+      }
+    },
+    "style": {
+      "type": "structure",
+      "attributes": {
+        "textColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#ffffff"
+          }
+        },
+        "backgroundColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#000000"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/location/configuration/banner-image-schema.json
+++ b/templates/croct/experience/e-commerce/location/configuration/banner-image-schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": true,
+      "position": 1
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {
+          "maximumSize": 307200
+        }
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 0
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/location/configuration/carousel-section-schema.json
+++ b/templates/croct/experience/e-commerce/location/configuration/carousel-section-schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Carousel section",
+  "attributes": {
+    "banners": {
+      "type": {
+        "type": "list",
+        "items": {
+          "id": "banner-image",
+          "type": "reference"
+        },
+        "itemLabel": "Banner"
+      },
+      "label": "Banners",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "autoplay": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Autoplay",
+      "private": false,
+      "optional": true,
+      "position": 3
+    },
+    "headline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Title",
+      "private": false,
+      "optional": true,
+      "position": 0,
+      "description": "The title displayed at the top of the section."
+    },
+    "description": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Description",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The description displayed bellow the title."
+    },
+    "pauseOnHover": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Pause on hover",
+      "private": false,
+      "optional": true,
+      "position": 4
+    }
+  },
+  "description": "A section of ordered banners."
+}

--- a/templates/croct/experience/e-commerce/location/configuration/home-carousel-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/location/configuration/home-carousel-experience-content.en.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/5f3601e3-7ada-4fdc-a2a1-9ea2c68ea29f"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/location/configuration/home-carousel-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/location/configuration/home-carousel-slot-content.en.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/b4cb19af-70ba-4fc9-a83e-e213b1fc7150"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/01462ecd-9323-4fa4-bba8-5d9affac996c"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/2edf720a-abd6-40b2-bf27-9f98eb59acab"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/location/cover.png
+++ b/templates/croct/experience/e-commerce/location/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37c13617b5e9b130826634fb2d5c2adc10b6a8bb83c4055a07b7d26b7c5ff894
+size 47201

--- a/templates/croct/experience/e-commerce/location/template.json5
+++ b/templates/croct/experience/e-commerce/location/template.json5
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Location-based experience",
+  "description": "A personalized experience based on the user's location.",
+  "metadata": {
+    "id": "use-case/e-commerce/location",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=location"
+    },
+    "categories": ["use-case/e-commerce"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/location/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/location/cover.png",
+    "installationUrl": "croct://use-case/e-commerce/location",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/location/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "new-york-city": {
+            "name": "New York city",
+            "criteria": "location's city is \"New York\""
+          }
+        },
+        "components": {
+          "banner-image": {
+            "name": "Banner image",
+            "schema": "${import('./configuration/banner-image-schema.json')}"
+          },
+          "carousel-section": {
+            "name": "Carousel section",
+            "description": "A section of ordered banners.",
+            "schema": "${import('./configuration/carousel-section-schema.json')}"
+          },
+          "announcement-bar": {
+            "name": "Announcement bar",
+            "description": "A small text bar featured at the top of a page.",
+            "schema": "${import('./configuration/announcement-bar-schema.json')}"
+          }
+        },
+        "slots": {
+          "announcement-bar": {
+            "name": "Announcement bar",
+            "component": "announcement-bar",
+            "content": {
+              "en": "${import('./configuration/announcement-bar-slot-content.en.json')}"
+            }
+          },
+          "home-carousel": {
+            "name": "Home carousel",
+            "component": "carousel-section",
+            "content": {
+              "en": "${import('./configuration/home-carousel-slot-content.en.json')}"
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "🗽 New York",
+            "draft": true,
+            "audiences": [
+              "new-york-city"
+            ],
+            "slots": [
+              "announcement-bar",
+              "home-carousel"
+            ],
+            "content": {
+              "default": {
+                "announcement-bar": {
+                  "en": "${import('./configuration/announcement-bar-experience-content.en.json')}"
+                },
+                "home-carousel": {
+                  "en": "${import('./configuration/home-carousel-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experience/e-commerce/marketing-campaign/README.md
+++ b/templates/croct/experience/e-commerce/marketing-campaign/README.md
@@ -1,0 +1,23 @@
+# Introduction
+
+This template defines a personalized experience for e-commerce visitors coming from a given campaign.
+
+It leverages [UTM parameters](https://docs.croct.com/reference/cql/data-types/marketing?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=instagram_campaign) from ad URLs to align onsite content with the visitor’s interests, creating a seamless and consistent journey from ad to landing page and beyond.
+
+## What's included
+
+This experience includes:
+
+- **Components:** banner image, CTA, navbar, and carousel section
+- **Slots:** navbar, carousel section, and section with featured products
+- **Audience:** `campaign's name matches "shoes"`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=marketing_campaign), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It allows, for instance, to add two or more campaigns to the same audience using [or](https://docs.croct.com/reference/cql/expressions/operations/logical#or), [and](https://docs.croct.com/reference/cql/expressions/operations/logical#and), [starts with](https://docs.croct.com/reference/cql/expressions/tests/string#starts-with), [ends with](https://docs.croct.com/reference/cql/expressions/tests/string#ends-with), or [matches](https://docs.croct.com/reference/cql/expressions/tests/string#matches).
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/e-commerce/marketing-campaign
+```

--- a/templates/croct/experience/e-commerce/marketing-campaign/configuration/banner-image-schema.json
+++ b/templates/croct/experience/e-commerce/marketing-campaign/configuration/banner-image-schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": true,
+      "position": 1
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {
+          "maximumSize": 307200
+        }
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 0
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/marketing-campaign/configuration/carousel-section-schema.json
+++ b/templates/croct/experience/e-commerce/marketing-campaign/configuration/carousel-section-schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Carousel section",
+  "attributes": {
+    "banners": {
+      "type": {
+        "type": "list",
+        "items": {
+          "id": "banner-image",
+          "type": "reference"
+        },
+        "itemLabel": "Banner"
+      },
+      "label": "Banners",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "autoplay": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Autoplay",
+      "private": false,
+      "optional": true,
+      "position": 3
+    },
+    "headline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Title",
+      "private": false,
+      "optional": true,
+      "position": 0,
+      "description": "The title displayed at the top of the section."
+    },
+    "description": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Description",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The description displayed bellow the title."
+    },
+    "pauseOnHover": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Pause on hover",
+      "private": false,
+      "optional": true,
+      "position": 4
+    }
+  },
+  "description": "A section of ordered banners."
+}

--- a/templates/croct/experience/e-commerce/marketing-campaign/configuration/cta-schema.json
+++ b/templates/croct/experience/e-commerce/marketing-campaign/configuration/cta-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": false,
+      "position": 1
+    },
+    "label": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Label",
+      "private": false,
+      "optional": false,
+      "position": 0
+    },
+    "appearance": {
+      "type": {
+        "type": "text",
+        "choices": {
+          "primary": {
+            "label": "Primary",
+            "default": true,
+            "position": 0
+          },
+          "secondary": {
+            "label": "Secondary",
+            "default": false,
+            "position": 1
+          }
+        }
+      },
+      "label": "Appearance",
+      "private": false,
+      "optional": false,
+      "position": 2
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/marketing-campaign/configuration/home-carousel-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/marketing-campaign/configuration/home-carousel-experience-content.en.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women-shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/281ddaa1-a46c-4d5d-905e-a861e7669fc0"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men-shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/238c3995-ed4f-4d76-8aa1-3183923c3061"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes-sale"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/f09710c0-0658-4304-9fe7-34a484520009"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/marketing-campaign/configuration/home-carousel-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/marketing-campaign/configuration/home-carousel-slot-content.en.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/b4cb19af-70ba-4fc9-a83e-e213b1fc7150"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/01462ecd-9323-4fa4-bba8-5d9affac996c"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/2edf720a-abd6-40b2-bf27-9f98eb59acab"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/marketing-campaign/configuration/home-featured-products-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/marketing-campaign/configuration/home-featured-products-experience-content.en.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/heels"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/4431b32c-9880-4fb7-981c-2ea774b09c73"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/flipflops"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/74b93c52-7574-4335-8ee2-a0a11c4dd646"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sneakers"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/3ea47b55-d16c-41d8-88a4-016c68418eb1"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "headline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Flash sale"
+      }
+    },
+    "description": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Online only: up to 70% off!"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/marketing-campaign/configuration/home-featured-products-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/marketing-campaign/configuration/home-featured-products-slot-content.en.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-shorts"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/75fdbcf6-ae52-428f-b9ce-80d4e3e40ffc"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-glasses"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/8918ccba-6a52-4de4-8cfd-a35750ac355b"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-flipflops"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e172f6af-9069-41db-ac93-5b5eaa7229bd"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "headline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Flash sale"
+      }
+    },
+    "description": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Online only: up to 70% off!"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/marketing-campaign/configuration/navbar-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/marketing-campaign/configuration/navbar-experience-content.en.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "items": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/new-shoes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "New Shoes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women-shoes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Women Shoes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men-shoes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Men Shoes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/clothes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Clothes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/accessories"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Accessories"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Sale"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "primaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/checkout"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Checkout"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "secondaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/login"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Login"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "secondary"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/marketing-campaign/configuration/navbar-schema.json
+++ b/templates/croct/experience/e-commerce/marketing-campaign/configuration/navbar-schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Header menu",
+  "attributes": {
+    "items": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": {
+                "type": "text",
+                "format": "url"
+              },
+              "label": "Link",
+              "private": false,
+              "optional": true,
+              "position": 1,
+              "description": "The target URL of the menu item."
+            },
+            "label": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Label",
+              "private": false,
+              "optional": false,
+              "position": 0,
+              "description": "The label of the menu item."
+            }
+          }
+        },
+        "itemLabel": "Menu item"
+      },
+      "label": "Items",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "primaryCta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Primary call to action",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The primary action button of the menu."
+    },
+    "secondaryCta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Secondary call to action",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The secondary action button of the menu."
+    }
+  },
+  "description": "A section of links and CTAs featured at the top of a page."
+}

--- a/templates/croct/experience/e-commerce/marketing-campaign/configuration/navbar-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/marketing-campaign/configuration/navbar-slot-content.en.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "items": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/new"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "New"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Women"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Men"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Shoes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/accessories"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Accessories"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Sale"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "primaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/checkout"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Checkout"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "secondaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/login"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Login"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "secondary"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/marketing-campaign/cover.png
+++ b/templates/croct/experience/e-commerce/marketing-campaign/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:608626e8ef40d4e3f19df3cb2f61d27b3485e88fa9a4da8b097b4850d7330638
+size 47459

--- a/templates/croct/experience/e-commerce/marketing-campaign/template.json5
+++ b/templates/croct/experience/e-commerce/marketing-campaign/template.json5
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Marketing campaign experience",
+  "description": "A personalized experience based on the marketing campaign associated with the session.",
+  "metadata": {
+    "id": "use-case/e-commerce/marketing-campaign",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=marketing_campaign"
+    },
+    "categories": ["use-case/e-commerce"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/marketing-campaign/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/marketing-campaign/cover.png",
+    "installationUrl": "croct://use-case/e-commerce/marketing-campaign",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/marketing-campaign/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "shoes-marketing-campaign": {
+            "name": "Shoes marketing campaign",
+            "criteria": "campaign's name matches \"shoes\""
+          }
+        },
+        "components": {
+          "banner-image": {
+            "name": "Banner image",
+            "schema": "${import('./configuration/banner-image-schema.json')}"
+          },
+          "cta": {
+            "name": "CTA",
+            "description": "A call to action button.",
+            "schema": "${import('./configuration/cta-schema.json')}"
+          },
+          "navbar": {
+            "name": "Navbar",
+            "description": "A section of links and CTAs featured at the top of a page.",
+            "schema": "${import('./configuration/navbar-schema.json')}"
+          },
+          "carousel-section": {
+            "name": "Carousel section",
+            "description": "A section of ordered banners.",
+            "schema": "${import('./configuration/carousel-section-schema.json')}"
+          }
+        },
+        "slots": {
+          "home-carousel": {
+            "name": "Home carousel",
+            "component": "carousel-section",
+            "content": {
+              "en": "${import('./configuration/home-carousel-slot-content.en.json')}"
+            }
+          },
+          "home-featured-products": {
+            "name": "Home featured products",
+            "component": "carousel-section",
+            "content": {
+              "en": "${import('./configuration/home-featured-products-slot-content.en.json')}"
+            }
+          },
+          "navbar": {
+            "name": "Navbar",
+            "component": "navbar",
+            "content": {
+              "en": "${import('./configuration/navbar-slot-content.en.json')}"
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "👠 Shoes marketing campaign",
+            "draft": true,
+            "audiences": [
+              "shoes-marketing-campaign"
+            ],
+            "slots": [
+              "home-featured-products",
+              "home-carousel",
+              "navbar"
+            ],
+            "content": {
+              "default": {
+                "home-featured-products": {
+                  "en": "${import('./configuration/home-featured-products-experience-content.en.json')}"
+                },
+                "home-carousel": {
+                  "en": "${import('./configuration/home-carousel-experience-content.en.json')}"
+                },
+                "navbar": {
+                  "en": "${import('./configuration/navbar-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experience/e-commerce/search-campaign/README.md
+++ b/templates/croct/experience/e-commerce/search-campaign/README.md
@@ -1,0 +1,27 @@
+# Introduction
+
+This template defines a personalized experience for e-commerce visitors coming from paid search campaigns.
+
+It leverages [UTM parameters](https://docs.croct.com/reference/cql/data-types/marketing?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=instagram_campaign) from ad URLs to align onsite content with the visitor’s search intent, creating a seamless and consistent journey from ad to landing page and beyond.
+
+## What's included
+
+This experience includes:
+
+- **Components:** banner image, CTA, navbar, and carousel section
+- **Slots:** navbar, carousel section, and section with featured products
+- **Audience:** `campaign's source is "google" and campaign's term matches "shoes"`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=search_campaign), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It allows, for instance, to add two or more campaigns to the same audience using [or](https://docs.croct.com/reference/cql/expressions/operations/logical#or), [and](https://docs.croct.com/reference/cql/expressions/operations/logical#and), [starts with](https://docs.croct.com/reference/cql/expressions/tests/string#starts-with), [ends with](https://docs.croct.com/reference/cql/expressions/tests/string#ends-with), or [matches](https://docs.croct.com/reference/cql/expressions/tests/string#matches).
+
+> 💬 utm_term
+>
+> Personalization with the `campaign's term` variable requires campaigns' final URLs with the `utm_term` parameter.
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/e-commerce/search-campaign
+```

--- a/templates/croct/experience/e-commerce/search-campaign/configuration/banner-image-schema.json
+++ b/templates/croct/experience/e-commerce/search-campaign/configuration/banner-image-schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": true,
+      "position": 1
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {
+          "maximumSize": 307200
+        }
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 0
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/search-campaign/configuration/carousel-section-schema.json
+++ b/templates/croct/experience/e-commerce/search-campaign/configuration/carousel-section-schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Carousel section",
+  "attributes": {
+    "banners": {
+      "type": {
+        "type": "list",
+        "items": {
+          "id": "banner-image",
+          "type": "reference"
+        },
+        "itemLabel": "Banner"
+      },
+      "label": "Banners",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "autoplay": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Autoplay",
+      "private": false,
+      "optional": true,
+      "position": 3
+    },
+    "headline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Title",
+      "private": false,
+      "optional": true,
+      "position": 0,
+      "description": "The title displayed at the top of the section."
+    },
+    "description": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Description",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The description displayed bellow the title."
+    },
+    "pauseOnHover": {
+      "type": {
+        "type": "boolean",
+        "label": {
+          "true": "Yes",
+          "false": "No"
+        },
+        "default": true
+      },
+      "label": "Pause on hover",
+      "private": false,
+      "optional": true,
+      "position": 4
+    }
+  },
+  "description": "A section of ordered banners."
+}

--- a/templates/croct/experience/e-commerce/search-campaign/configuration/cta-schema.json
+++ b/templates/croct/experience/e-commerce/search-campaign/configuration/cta-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": false,
+      "position": 1
+    },
+    "label": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Label",
+      "private": false,
+      "optional": false,
+      "position": 0
+    },
+    "appearance": {
+      "type": {
+        "type": "text",
+        "choices": {
+          "primary": {
+            "label": "Primary",
+            "default": true,
+            "position": 0
+          },
+          "secondary": {
+            "label": "Secondary",
+            "default": false,
+            "position": 1
+          }
+        }
+      },
+      "label": "Appearance",
+      "private": false,
+      "optional": false,
+      "position": 2
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/search-campaign/configuration/home-carousel-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/search-campaign/configuration/home-carousel-experience-content.en.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women-shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/281ddaa1-a46c-4d5d-905e-a861e7669fc0"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men-shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/238c3995-ed4f-4d76-8aa1-3183923c3061"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes-sale"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/f09710c0-0658-4304-9fe7-34a484520009"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/search-campaign/configuration/home-carousel-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/search-campaign/configuration/home-carousel-slot-content.en.json
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/b4cb19af-70ba-4fc9-a83e-e213b1fc7150"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/01462ecd-9323-4fa4-bba8-5d9affac996c"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/2edf720a-abd6-40b2-bf27-9f98eb59acab"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/search-campaign/configuration/home-featured-products-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/search-campaign/configuration/home-featured-products-experience-content.en.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/heels"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/4431b32c-9880-4fb7-981c-2ea774b09c73"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/flipflops"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/74b93c52-7574-4335-8ee2-a0a11c4dd646"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sneakers"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/3ea47b55-d16c-41d8-88a4-016c68418eb1"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "headline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Flash sale"
+      }
+    },
+    "description": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Online only: up to 70% off!"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/search-campaign/configuration/home-featured-products-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/search-campaign/configuration/home-featured-products-slot-content.en.json
@@ -1,0 +1,82 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "banners": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-shorts"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/75fdbcf6-ae52-428f-b9ce-80d4e3e40ffc"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-glasses"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/8918ccba-6a52-4de4-8cfd-a35750ac355b"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale-flipflops"
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e172f6af-9069-41db-ac93-5b5eaa7229bd"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "headline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Flash sale"
+      }
+    },
+    "description": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Online only: up to 70% off!"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/search-campaign/configuration/navbar-experience-content.en.json
+++ b/templates/croct/experience/e-commerce/search-campaign/configuration/navbar-experience-content.en.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "items": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/new-shoes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "New Shoes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women-shoes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Women Shoes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men-shoes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Men Shoes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/clothes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Clothes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/accessories"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Accessories"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Sale"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "primaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/checkout"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Checkout"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "secondaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/login"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Login"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "secondary"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/search-campaign/configuration/navbar-schema.json
+++ b/templates/croct/experience/e-commerce/search-campaign/configuration/navbar-schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Header menu",
+  "attributes": {
+    "items": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": {
+                "type": "text",
+                "format": "url"
+              },
+              "label": "Link",
+              "private": false,
+              "optional": true,
+              "position": 1,
+              "description": "The target URL of the menu item."
+            },
+            "label": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Label",
+              "private": false,
+              "optional": false,
+              "position": 0,
+              "description": "The label of the menu item."
+            }
+          }
+        },
+        "itemLabel": "Menu item"
+      },
+      "label": "Items",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "primaryCta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Primary call to action",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The primary action button of the menu."
+    },
+    "secondaryCta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Secondary call to action",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The secondary action button of the menu."
+    }
+  },
+  "description": "A section of links and CTAs featured at the top of a page."
+}

--- a/templates/croct/experience/e-commerce/search-campaign/configuration/navbar-slot-content.en.json
+++ b/templates/croct/experience/e-commerce/search-campaign/configuration/navbar-slot-content.en.json
@@ -1,0 +1,177 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "items": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/new"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "New"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/women"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Women"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/men"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Men"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/shoes"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Shoes"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/accessories"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Accessories"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/sale"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Sale"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "primaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/checkout"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Checkout"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "secondaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/login"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Login"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "secondary"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/e-commerce/search-campaign/cover.png
+++ b/templates/croct/experience/e-commerce/search-campaign/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21fd51271b0e560998e01d07bdbd6fa9dc6aa43db04160125ab440e6b8aeb4f4
+size 45330

--- a/templates/croct/experience/e-commerce/search-campaign/template.json5
+++ b/templates/croct/experience/e-commerce/search-campaign/template.json5
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Search campaign experience",
+  "description": "A personalized experience based on the search campaign associated with the session.",
+  "metadata": {
+    "id": "use-case/e-commerce/search-campaign",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.e_commerce&utm_content=search_campaign"
+    },
+    "categories": ["use-case/e-commerce"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/search-campaign/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/search-campaign/cover.png",
+    "installationUrl": "croct://use-case/e-commerce/search-campaign",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/e-commerce/search-campaign/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "shoes-google-campaign": {
+            "name": "Shoes Google campaign",
+            "criteria": "campaign's source is \"google\" and campaign's term matches \"shoes\""
+          }
+        },
+        "components": {
+          "banner-image": {
+            "name": "Banner image",
+            "schema": "${import('./configuration/banner-image-schema.json')}"
+          },
+          "cta": {
+            "name": "CTA",
+            "description": "A call to action button.",
+            "schema": "${import('./configuration/cta-schema.json')}"
+          },
+          "navbar": {
+            "name": "Navbar",
+            "description": "A section of links and CTAs featured at the top of a page.",
+            "schema": "${import('./configuration/navbar-schema.json')}"
+          },
+          "carousel-section": {
+            "name": "Carousel section",
+            "description": "A section of ordered banners.",
+            "schema": "${import('./configuration/carousel-section-schema.json')}"
+          }
+        },
+        "slots": {
+          "home-carousel": {
+            "name": "Home carousel",
+            "component": "carousel-section",
+            "content": {
+              "en": "${import('./configuration/home-carousel-slot-content.en.json')}"
+            }
+          },
+          "home-featured-products": {
+            "name": "Home featured products",
+            "component": "carousel-section",
+            "content": {
+              "en": "${import('./configuration/home-featured-products-slot-content.en.json')}"
+            }
+          },
+          "navbar": {
+            "name": "Navbar",
+            "component": "navbar",
+            "content": {
+              "en": "${import('./configuration/navbar-slot-content.en.json')}"
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "👠 Shoes Google campaign",
+            "draft": true,
+            "audiences": [
+              "shoes-google-campaign"
+            ],
+            "slots": [
+              "home-featured-products",
+              "home-carousel",
+              "navbar"
+            ],
+            "content": {
+              "default": {
+                "home-featured-products": {
+                  "en": "${import('./configuration/home-featured-products-experience-content.en.json')}"
+                },
+                "home-carousel": {
+                  "en": "${import('./configuration/home-carousel-experience-content.en.json')}"
+                },
+                "navbar": {
+                  "en": "${import('./configuration/navbar-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experience/saas/abm-campaign/README.md
+++ b/templates/croct/experience/saas/abm-campaign/README.md
@@ -1,0 +1,23 @@
+# Introduction
+
+This template defines a personalized experience for SaaS visitors coming from ABM campaigns.
+
+It leverages [UTM parameters](https://docs.croct.com/reference/cql/data-types/marketing?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=abm_campaign) from ad URLs to align onsite content with the visitor’s interests, creating a seamless and consistent journey from ad to landing page and beyond.
+
+## What's included
+
+This experience includes:
+
+- **Components:** CTA, announcement bar, and hero section
+- **Slots:** announcement bar and home hero section
+- **Audience:** `campaign's source is "linkedin" and campaign's name matches "acme"`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=abm_campaign), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It allows, for instance, to add two or more campaigns to the same audience using [or](https://docs.croct.com/reference/cql/expressions/operations/logical#or), [and](https://docs.croct.com/reference/cql/expressions/operations/logical#and), [starts with](https://docs.croct.com/reference/cql/expressions/tests/string#starts-with), [ends with](https://docs.croct.com/reference/cql/expressions/tests/string#ends-with), or [matches](https://docs.croct.com/reference/cql/expressions/tests/string#matches).
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/saas/abm-campaign
+```

--- a/templates/croct/experience/saas/abm-campaign/configuration/announcement-bar-experience-content.en.json
+++ b/templates/croct/experience/saas/abm-campaign/configuration/announcement-bar-experience-content.en.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://www.example.com/case/morley"
+      }
+    },
+    "text": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Learn how Morley uses Listo to increase productivity"
+      }
+    },
+    "style": {
+      "type": "structure",
+      "attributes": {
+        "textColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#ffffff"
+          }
+        },
+        "backgroundColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#000000"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/abm-campaign/configuration/announcement-bar-schema.json
+++ b/templates/croct/experience/saas/abm-campaign/configuration/announcement-bar-schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Announcement bar",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The link to navigate by clicking on the top bar."
+    },
+    "text": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Message",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The message to display in the top bar."
+    },
+    "style": {
+      "type": {
+        "type": "structure",
+        "attributes": {
+          "textColor": {
+            "type": {
+              "type": "text",
+              "format": "color"
+            },
+            "label": "Text Color",
+            "private": false,
+            "optional": false,
+            "position": 1,
+            "description": "The text color of the top bar."
+          },
+          "backgroundColor": {
+            "type": {
+              "type": "text",
+              "format": "color"
+            },
+            "label": "Background Color",
+            "private": false,
+            "optional": false,
+            "position": 0,
+            "description": "The background color of the top bar."
+          }
+        }
+      },
+      "label": "Style",
+      "position": 2,
+      "description": "The style of the top bar."
+    }
+  },
+  "description": "A small text bar featured at the top of a page."
+}

--- a/templates/croct/experience/saas/abm-campaign/configuration/announcement-bar-slot-content.en.json
+++ b/templates/croct/experience/saas/abm-campaign/configuration/announcement-bar-slot-content.en.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://www.producthunt.com/"
+      }
+    },
+    "text": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "We're live on Product Hunt!"
+      }
+    },
+    "style": {
+      "type": "structure",
+      "attributes": {
+        "textColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#ffffff"
+          }
+        },
+        "backgroundColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#000000"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/abm-campaign/configuration/cta-schema.json
+++ b/templates/croct/experience/saas/abm-campaign/configuration/cta-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": false,
+      "position": 1
+    },
+    "label": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Label",
+      "private": false,
+      "optional": false,
+      "position": 0
+    },
+    "appearance": {
+      "type": {
+        "type": "text",
+        "choices": {
+          "primary": {
+            "label": "Primary",
+            "default": true,
+            "position": 0
+          },
+          "secondary": {
+            "label": "Secondary",
+            "default": false,
+            "position": 1
+          }
+        }
+      },
+      "label": "Appearance",
+      "private": false,
+      "optional": false,
+      "position": 2
+    }
+  }
+}

--- a/templates/croct/experience/saas/abm-campaign/configuration/hero-section-schema.json
+++ b/templates/croct/experience/saas/abm-campaign/configuration/hero-section-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Hero section",
+  "attributes": {
+    "cta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Call to action",
+      "private": false,
+      "optional": true,
+      "position": 3,
+      "description": "The main call-to-action button."
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {}
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 2,
+      "description": "The image to display alongside the heading and tagline."
+    },
+    "heading": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Heading",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The main heading of the page."
+    },
+    "tagline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Tagline",
+      "private": false,
+      "optional": false,
+      "position": 1,
+      "description": "The tagline of the page."
+    }
+  },
+  "description": "A big section featured at the top of a page."
+}

--- a/templates/croct/experience/saas/abm-campaign/configuration/home-hero-experience-content.en.json
+++ b/templates/croct/experience/saas/abm-campaign/configuration/home-hero-experience-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/sales"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Request a demo"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/1dbdee32-c14e-4b04-b7e7-8663b54eef24"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for business"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Large companies like ACME love using Listo."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/abm-campaign/configuration/home-hero-slot-content.en.json
+++ b/templates/croct/experience/saas/abm-campaign/configuration/home-hero-slot-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Get started"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/88288403-0442-4cf3-84b9-0a4a3a680218"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for everyone"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for everything you need."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/abm-campaign/cover.png
+++ b/templates/croct/experience/saas/abm-campaign/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5624d92cd375cdac4b275c8032fd1762592c5e690eca5afca07506d9ae7af457
+size 45690

--- a/templates/croct/experience/saas/abm-campaign/template.json5
+++ b/templates/croct/experience/saas/abm-campaign/template.json5
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "ABM campaign experience",
+  "description": "A personalized experience based on the ABM campaign associated with the session.",
+  "metadata": {
+    "id": "use-case/saas/abm-campaign",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=abm_campaign"
+    },
+    "categories": ["use-case/saas"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/abm-campaign/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/abm-campaign/cover.png",
+    "installationUrl": "croct://use-case/saas/abm-campaign",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/abm-campaign/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "acme-abm-campaign": {
+            "name": "ACME ABM campaign",
+            "criteria": "campaign's source is \"linkedin\" and campaign's name matches \"acme\""
+          }
+        },
+        "components": {
+          "cta": {
+            "name": "CTA",
+            "description": "A call to action button.",
+            "schema": "${import('./configuration/cta-schema.json')}"
+          },
+          "announcement-bar": {
+            "name": "Announcement bar",
+            "description": "A small text bar featured at the top of a page.",
+            "schema": "${import('./configuration/announcement-bar-schema.json')}"
+          },
+          "hero-section": {
+            "name": "Hero section",
+            "description": "A big section featured at the top of a page.",
+            "schema": "${import('./configuration/hero-section-schema.json')}"
+          }
+        },
+        "slots": {
+          "home-hero": {
+            "name": "Home hero",
+            "component": "hero-section",
+            "content": {
+              "en": "${import('./configuration/home-hero-slot-content.en.json')}",
+            }
+          },
+          "announcement-bar": {
+            "name": "Announcement bar",
+            "component": "announcement-bar",
+            "content": {
+              "en": "${import('./configuration/announcement-bar-slot-content.en.json')}"
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "🎯 ABM campaign",
+            "draft": true,
+            "audiences": [
+              "acme-abm-campaign"
+            ],
+            "slots": [
+              "home-hero",
+              "announcement-bar"
+            ],
+            "content": {
+              "default": {
+                "home-hero": {
+                  "en": "${import('./configuration/home-hero-experience-content.en.json')}"
+                },
+                "announcement-bar": {
+                  "en": "${import('./configuration/announcement-bar-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experience/saas/customer/README.md
+++ b/templates/croct/experience/saas/customer/README.md
@@ -1,0 +1,23 @@
+# Introduction
+
+This template defines a personalized experience for SaaS visitors identified as existing customers.
+
+By segmenting customers from new visitors, the experience can emphasize loyalty-building through exclusive benefits, rewards, and product recommendations based on purchase history.
+
+## What's included
+
+This experience includes:
+
+- **Components:** CTA, announcement bar, and hero section
+- **Slots:** announcement bar and home hero section
+- **Audience:** `user's activities include "login" and user's plan is not "free"`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=customer), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It supports profile [enrichment with first-party data](https://docs.croct.com/reference/sdk/javascript/data-collection) and allows the use of [custom attributes](https://docs.croct.com/reference/cql/data-types/user) to fine-tune personalization strategies. 
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/saas/customer
+```

--- a/templates/croct/experience/saas/customer/configuration/announcement-bar-experience-content.en.json
+++ b/templates/croct/experience/saas/customer/configuration/announcement-bar-experience-content.en.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://www.example.com/ai"
+      }
+    },
+    "text": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "You can now use AI to streamline your note-taking. Upgrade you account today!"
+      }
+    },
+    "style": {
+      "type": "structure",
+      "attributes": {
+        "textColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#ffffff"
+          }
+        },
+        "backgroundColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#000000"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/customer/configuration/announcement-bar-schema.json
+++ b/templates/croct/experience/saas/customer/configuration/announcement-bar-schema.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Announcement bar",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The link to navigate by clicking on the top bar."
+    },
+    "text": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Message",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The message to display in the top bar."
+    },
+    "style": {
+      "type": {
+        "type": "structure",
+        "attributes": {
+          "textColor": {
+            "type": {
+              "type": "text",
+              "format": "color"
+            },
+            "label": "Text Color",
+            "private": false,
+            "optional": false,
+            "position": 1,
+            "description": "The text color of the top bar."
+          },
+          "backgroundColor": {
+            "type": {
+              "type": "text",
+              "format": "color"
+            },
+            "label": "Background Color",
+            "private": false,
+            "optional": false,
+            "position": 0,
+            "description": "The background color of the top bar."
+          }
+        }
+      },
+      "label": "Style",
+      "position": 2,
+      "description": "The style of the top bar."
+    }
+  },
+  "description": "A small text bar featured at the top of a page."
+}

--- a/templates/croct/experience/saas/customer/configuration/announcement-bar-slot-content.en.json
+++ b/templates/croct/experience/saas/customer/configuration/announcement-bar-slot-content.en.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://www.producthunt.com/"
+      }
+    },
+    "text": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "We're live on Product Hunt!"
+      }
+    },
+    "style": {
+      "type": "structure",
+      "attributes": {
+        "textColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#ffffff"
+          }
+        },
+        "backgroundColor": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "#000000"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/customer/configuration/cta-schema.json
+++ b/templates/croct/experience/saas/customer/configuration/cta-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": false,
+      "position": 1
+    },
+    "label": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Label",
+      "private": false,
+      "optional": false,
+      "position": 0
+    },
+    "appearance": {
+      "type": {
+        "type": "text",
+        "choices": {
+          "primary": {
+            "label": "Primary",
+            "default": true,
+            "position": 0
+          },
+          "secondary": {
+            "label": "Secondary",
+            "default": false,
+            "position": 1
+          }
+        }
+      },
+      "label": "Appearance",
+      "private": false,
+      "optional": false,
+      "position": 2
+    }
+  }
+}

--- a/templates/croct/experience/saas/customer/configuration/hero-section-schema.json
+++ b/templates/croct/experience/saas/customer/configuration/hero-section-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Hero section",
+  "attributes": {
+    "cta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Call to action",
+      "private": false,
+      "optional": true,
+      "position": 3,
+      "description": "The main call-to-action button."
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {}
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 2,
+      "description": "The image to display alongside the heading and tagline."
+    },
+    "heading": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Heading",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The main heading of the page."
+    },
+    "tagline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Tagline",
+      "private": false,
+      "optional": false,
+      "position": 1,
+      "description": "The tagline of the page."
+    }
+  },
+  "description": "A big section featured at the top of a page."
+}

--- a/templates/croct/experience/saas/customer/configuration/home-hero-experience-content.en.json
+++ b/templates/croct/experience/saas/customer/configuration/home-hero-experience-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/ai"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Learn more"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/d50c93eb-f6b6-40ae-9f6c-417e706db961"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Introducing Listo AI"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Upgrade and start using our new feature today."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/customer/configuration/home-hero-slot-content.en.json
+++ b/templates/croct/experience/saas/customer/configuration/home-hero-slot-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Get started"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/88288403-0442-4cf3-84b9-0a4a3a680218"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for everyone"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for everything you need."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/customer/configuration/navbar-experience-content.en.json
+++ b/templates/croct/experience/saas/customer/configuration/navbar-experience-content.en.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "items": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/features"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Features"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/new"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "What's new"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/templates"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Templates"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/blog"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Blog"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Support"
+              }
+            },
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/blog"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "primaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signin"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Sign in"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/customer/configuration/navbar-schema.json
+++ b/templates/croct/experience/saas/customer/configuration/navbar-schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Navbar",
+  "attributes": {
+    "items": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": {
+                "type": "text",
+                "format": "url"
+              },
+              "label": "Link",
+              "private": false,
+              "optional": true,
+              "position": 1,
+              "description": "The target URL of the menu item."
+            },
+            "label": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Label",
+              "private": false,
+              "optional": false,
+              "position": 0,
+              "description": "The label of the menu item."
+            }
+          }
+        },
+        "itemLabel": "Menu item"
+      },
+      "label": "Items",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "primaryCta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Primary call to action",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The primary action button of the menu."
+    },
+    "secondaryCta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Secondary call to action",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The secondary action button of the menu."
+    }
+  },
+  "description": "A section of links and CTAs featured at the top of a page."
+}

--- a/templates/croct/experience/saas/customer/configuration/navbar-slot-content.en.json
+++ b/templates/croct/experience/saas/customer/configuration/navbar-slot-content.en.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "items": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/features"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Features"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/students"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "For students"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/business"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "For business"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/personal"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "For you"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/pricing"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Pricing"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "primaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Sign up"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "secondaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/sales"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "For business"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "secondary"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/customer/cover.png
+++ b/templates/croct/experience/saas/customer/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1680f489775e066756d8a9c1d235034173133baee28b489a2a7b37b148969026
+size 44140

--- a/templates/croct/experience/saas/customer/template.json5
+++ b/templates/croct/experience/saas/customer/template.json5
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Customer experience",
+  "description": "A personalized experience for users who are paid customers.",
+  "metadata": {
+    "id": "use-case/saas/customer",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=customer"
+    },
+    "categories": ["use-case/saas"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/customer/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/customer/cover.png",
+    "installationUrl": "croct://use-case/saas/customer",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/customer/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "customers": {
+            "name": "Customers",
+            "criteria": "user's activities include \"login\" and user's plan is not \"free\""
+          }
+        },
+        "components": {
+          "cta": {
+            "name": "CTA",
+            "description": "A call to action button.",
+            "schema": "${import('./configuration/cta-schema.json')}"
+          },
+          "navbar": {
+            "name": "Navbar",
+            "description": "A section of links and CTAs featured at the top of a page.",
+            "schema": "${import('./configuration/navbar-schema.json')}"
+          },
+          "announcement-bar": {
+            "name": "Announcement bar",
+            "description": "A small text bar featured at the top of a page.",
+            "schema": "${import('./configuration/announcement-bar-schema.json')}"
+          },
+          "hero-section": {
+            "name": "Hero section",
+            "description": "A big section featured at the top of a page.",
+            "schema": "${import('./configuration/hero-section-schema.json')}"
+          }
+        },
+        "slots": {
+          "navbar": {
+            "name": "Navbar",
+            "component": "navbar",
+            "content": {
+              "en": "${import('./configuration/navbar-slot-content.en.json')}"
+            }
+          },
+          "home-hero": {
+            "name": "Home hero",
+            "component": "hero-section",
+            "content": {
+              "en": "${import('./configuration/home-hero-slot-content.en.json')}",
+            }
+          },
+          "announcement-bar": {
+            "name": "Announcement bar",
+            "component": "announcement-bar",
+            "content": {
+              "en": "${import('./configuration/announcement-bar-slot-content.en.json')}"
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "🥰 Customers",
+            "draft": true,
+            "audiences": [
+              "customers"
+            ],
+            "slots": [
+              "home-hero",
+              "announcement-bar",
+              "navbar"
+            ],
+            "content": {
+              "default": {
+                "home-hero": {
+                  "en": "${import('./configuration/home-hero-experience-content.en.json')}"
+                },
+                "announcement-bar": {
+                  "en": "${import('./configuration/announcement-bar-experience-content.en.json')}"
+                },
+                "navbar": {
+                  "en": "${import('./configuration/navbar-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experience/saas/interest/README.md
+++ b/templates/croct/experience/saas/interest/README.md
@@ -1,0 +1,21 @@
+# Introduction
+
+This template defines a personalized experience for SaaS websites that uses data from multiple sources, such as onsite behavior and inferred [interests](https://docs.croct.com/reference/cql/data-types/user#user-interests-prop?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=interest), to deliver tailored recommendations for products, blog posts, and other offerings.
+
+## What's included
+
+This experience includes:
+
+- **Components:** CTA, content cards, hero section, and testimonials
+- **Slots:** home hero section, home featured topics section, and testimonials
+- **Audience:** `user's interest includes "student"`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=interest), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It allows, for instance, to add two or more interests to the same audience using [or](https://docs.croct.com/reference/cql/expressions/operations/logical#or), [and](https://docs.croct.com/reference/cql/expressions/operations/logical#and), or [these quantifiers](https://docs.croct.com/reference/cql/expressions/quantifiers).
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/saas/interest
+```

--- a/templates/croct/experience/saas/interest/configuration/content-cards-schema.json
+++ b/templates/croct/experience/saas/interest/configuration/content-cards-schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Content cards",
+  "attributes": {
+    "cards": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": {
+                "id": "cta",
+                "type": "reference"
+              },
+              "label": "Call to action",
+              "private": false,
+              "optional": true,
+              "position": 3
+            },
+            "image": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Image",
+              "private": false,
+              "optional": true,
+              "position": 0,
+              "description": "The URL or path to an illustration image."
+            },
+            "title": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Title",
+              "private": false,
+              "optional": false,
+              "position": 1,
+              "description": "The title inside the card."
+            },
+            "description": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Description",
+              "private": false,
+              "optional": true,
+              "position": 2,
+              "description": "A short description."
+            }
+          }
+        },
+        "itemLabel": "Card"
+      },
+      "label": "Cards",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "title": {
+      "type": {
+        "type": "text"
+      },
+      "label": "Title",
+      "private": false,
+      "optional": true,
+      "position": 0
+    },
+    "description": {
+      "type": {
+        "type": "text"
+      },
+      "label": "Description",
+      "private": false,
+      "optional": true,
+      "position": 1
+    }
+  },
+  "description": "A section featuring cards with content."
+}

--- a/templates/croct/experience/saas/interest/configuration/cta-schema.json
+++ b/templates/croct/experience/saas/interest/configuration/cta-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": false,
+      "position": 1
+    },
+    "label": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Label",
+      "private": false,
+      "optional": false,
+      "position": 0
+    },
+    "appearance": {
+      "type": {
+        "type": "text",
+        "choices": {
+          "primary": {
+            "label": "Primary",
+            "default": true,
+            "position": 0
+          },
+          "secondary": {
+            "label": "Secondary",
+            "default": false,
+            "position": 1
+          }
+        }
+      },
+      "label": "Appearance",
+      "private": false,
+      "optional": false,
+      "position": 2
+    }
+  }
+}

--- a/templates/croct/experience/saas/interest/configuration/hero-section-schema.json
+++ b/templates/croct/experience/saas/interest/configuration/hero-section-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Hero section",
+  "attributes": {
+    "cta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Call to action",
+      "private": false,
+      "optional": true,
+      "position": 3,
+      "description": "The main call-to-action button."
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {}
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 2,
+      "description": "The image to display alongside the heading and tagline."
+    },
+    "heading": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Heading",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The main heading of the page."
+    },
+    "tagline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Tagline",
+      "private": false,
+      "optional": false,
+      "position": 1,
+      "description": "The tagline of the page."
+    }
+  },
+  "description": "A big section featured at the top of a page."
+}

--- a/templates/croct/experience/saas/interest/configuration/home-featured-topics-experience-content.en.json
+++ b/templates/croct/experience/saas/interest/configuration/home-featured-topics-experience-content.en.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cards": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/checklists"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/9b7f0ed2-e25a-4f63-b92d-ed6d6b5bd905"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Checklists"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Create simple checklists so you don't miss any homework."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/calendar"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e773b72d-4f36-45f6-bb14-6ae3c67b59d3"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Calendar"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Plan ahead and create an effective study plan."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/reminders"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/40f4e16a-d8e0-4f5b-a76d-ef75cd956adf"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Reminders"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Never forget projects due dates."
+              }
+            }
+          }
+        }
+      ]
+    },
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why Listo is perfect for students"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/interest/configuration/home-featured-topics-slot-content.en.json
+++ b/templates/croct/experience/saas/interest/configuration/home-featured-topics-slot-content.en.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cards": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/checklists"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/9b7f0ed2-e25a-4f63-b92d-ed6d6b5bd905"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Checklists"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Create simple checklists so you don't miss anything."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/calendar"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e773b72d-4f36-45f6-bb14-6ae3c67b59d3"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Calendar"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Plan ahead and organize your week."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/reminders"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/40f4e16a-d8e0-4f5b-a76d-ef75cd956adf"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Reminders"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Never forget important things."
+              }
+            }
+          }
+        }
+      ]
+    },
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why Listo is better"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/interest/configuration/home-hero-experience-content.en.json
+++ b/templates/croct/experience/saas/interest/configuration/home-hero-experience-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Start for free"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/5aa56d73-5e21-4ced-b9b7-146f630752e9"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for students"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for your study plan."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/interest/configuration/home-hero-slot-content.en.json
+++ b/templates/croct/experience/saas/interest/configuration/home-hero-slot-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Get started"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/88288403-0442-4cf3-84b9-0a4a3a680218"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for everyone"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for everything you need."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/interest/configuration/testimonials-experience-content.en.json
+++ b/templates/croct/experience/saas/interest/configuration/testimonials-experience-content.en.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why students love us"
+      }
+    },
+    "testimonials": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I never forget a project due date, thanks to Listo."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "John Doe"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e47cecc9-44dd-450f-8ae3-b69705366e9b"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I'm stunned by the quality of this app. It's a perfect planner."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Carol Duran"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/91dade3c-f2c8-4537-8489-0c40e97bdd5a"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Trust me, they're good. Their checklist is the best."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Alex Bobby"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/d92cab97-b052-482c-a0fa-2e2204d9f92c"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/saas/interest/configuration/testimonials-schema.json
+++ b/templates/croct/experience/saas/interest/configuration/testimonials-schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Testimonials",
+  "attributes": {
+    "title": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Title",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The title displayed at the top of the section."
+    },
+    "testimonials": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Logo",
+              "private": false,
+              "optional": true,
+              "position": 3,
+              "description": "The logo of the company the author works for."
+            },
+            "quote": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Quote",
+              "private": false,
+              "optional": false,
+              "position": 0,
+              "description": "The quote or feedback from the customer."
+            },
+            "author": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Author",
+              "private": false,
+              "optional": false,
+              "position": 1,
+              "description": "The name or title of the person providing the testimonial."
+            },
+            "headshot": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Headshot",
+              "private": false,
+              "optional": true,
+              "position": 2,
+              "description": "The headshot of the author of the testimonial."
+            }
+          }
+        },
+        "itemLabel": "Testimonial"
+      },
+      "label": "Testimonials",
+      "private": false,
+      "optional": false,
+      "position": 1
+    }
+  },
+  "description": "A section featuring testimonials."
+}

--- a/templates/croct/experience/saas/interest/configuration/testimonials-slot-content.en.json
+++ b/templates/croct/experience/saas/interest/configuration/testimonials-slot-content.en.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why they love us"
+      }
+    },
+    "testimonials": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/6245b2c3-ce4f-4d02-8f3b-e2200ab09776"
+              }
+            },
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "This is the best alternative you'll find in the market."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "John Doe"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e47cecc9-44dd-450f-8ae3-b69705366e9b"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/889f3411-116e-4db9-945a-8e6614d71b78"
+              }
+            },
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I'm stunned by the quality of this app. It's perfect!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Carol Duran"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/91dade3c-f2c8-4537-8489-0c40e97bdd5a"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/ac1067ea-820b-4a17-8854-94936151ae74"
+              }
+            },
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Trust me, they're good. Their support team is amazing."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Alex Bobby"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/d92cab97-b052-482c-a0fa-2e2204d9f92c"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/saas/interest/cover.png
+++ b/templates/croct/experience/saas/interest/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:baf0133204655ed86ed139a8aaa79440a549a82c0c161d2f157d4bb34b11e28b
+size 49124

--- a/templates/croct/experience/saas/interest/template.json5
+++ b/templates/croct/experience/saas/interest/template.json5
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Interest-based experience",
+  "description": "A personalized experience based on the user's interests.",
+  "metadata": {
+    "id": "use-case/saas/interest",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=interest"
+    },
+    "categories": ["use-case/saas"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/interest/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/interest/cover.png",
+    "installationUrl": "croct://use-case/saas/interest",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/interest/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "student-interest": {
+            "name": "Student interest",
+            "criteria": "user's interest includes \"student\""
+          }
+        },
+        "components": {
+          "content-cards": {
+            "name": "Content cards",
+            "description": "A section featuring cards with content.",
+            "schema": "${import('./configuration/content-cards-schema.json')}"
+          },
+          "cta": {
+            "name": "CTA",
+            "description": "A call to action button.",
+            "schema": "${import('./configuration/cta-schema.json')}"
+          },
+          "testimonials": {
+            "name": "Testimonials",
+            "description": "A section featuring testimonials.",
+            "schema": "${import('./configuration/testimonials-schema.json')}"
+          },
+          "hero-section": {
+            "name": "Hero section",
+            "description": "A big section featured at the top of a page.",
+            "schema": "${import('./configuration/hero-section-schema.json')}"
+          }
+        },
+        "slots": {
+          "home-featured-topics": {
+            "name": "Home featured topics",
+            "component": "content-cards",
+            "content": {
+              "en": "${import('./configuration/home-featured-topics-slot-content.en.json')}"
+            }
+          },
+          "testimonials": {
+            "name": "Testimonials",
+            "component": "testimonials",
+            "content": {
+              "en": "${import('./configuration/testimonials-slot-content.en.json')}"
+            }
+          },
+          "home-hero": {
+            "name": "Home hero",
+            "component": "hero-section",
+            "content": {
+              "en": "${import('./configuration/home-hero-slot-content.en.json')}",
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "🎓 Student interest",
+            "draft": true,
+            "audiences": [
+              "student-interest"
+            ],
+            "slots": [
+              "home-featured-topics",
+              "home-hero",
+              "testimonials"
+            ],
+            "content": {
+              "default": {
+                "home-featured-topics": {
+                  "en": "${import('./configuration/home-featured-topics-experience-content.en.json')}"
+                },
+                "home-hero": {
+                  "en": "${import('./configuration/home-hero-experience-content.en.json')}"
+                },
+                "testimonials": {
+                  "en": "${import('./configuration/testimonials-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experience/saas/landing-page/README.md
+++ b/templates/croct/experience/saas/landing-page/README.md
@@ -1,0 +1,23 @@
+# Introduction
+
+This template defines a personalized experience for SaaS visitors based on the first page they land on.
+
+By referencing the [session's landing page](https://docs.croct.com/reference/cql/data-types/session?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=landing_page#web-session-landingpage-prop), it’s possible to infer visitor intent and adjust onsite content to create a consistent and relevant experience across the website.
+
+## What's included
+
+This experience includes:
+
+- **Components:** CTA, content cards, hero section, and testimonials
+- **Slots:** home hero section, home featured topics section, and testimonials
+- **Audience:** `session's landingPage matches "student"`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=landing_page), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It allows, for instance, to add two or more landing pages to the same audience using [or](https://docs.croct.com/reference/cql/expressions/operations/logical#or), [and](https://docs.croct.com/reference/cql/expressions/operations/logical#and), [starts with](https://docs.croct.com/reference/cql/expressions/tests/string#starts-with), [ends with](https://docs.croct.com/reference/cql/expressions/tests/string#ends-with), or [matches](https://docs.croct.com/reference/cql/expressions/tests/string#matches).
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/saas/landing-page
+```

--- a/templates/croct/experience/saas/landing-page/configuration/content-cards-schema.json
+++ b/templates/croct/experience/saas/landing-page/configuration/content-cards-schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Content cards",
+  "attributes": {
+    "cards": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": {
+                "id": "cta",
+                "type": "reference"
+              },
+              "label": "Call to action",
+              "private": false,
+              "optional": true,
+              "position": 3
+            },
+            "image": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Image",
+              "private": false,
+              "optional": true,
+              "position": 0,
+              "description": "The URL or path to an illustration image."
+            },
+            "title": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Title",
+              "private": false,
+              "optional": false,
+              "position": 1,
+              "description": "The title inside the card."
+            },
+            "description": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Description",
+              "private": false,
+              "optional": true,
+              "position": 2,
+              "description": "A short description."
+            }
+          }
+        },
+        "itemLabel": "Card"
+      },
+      "label": "Cards",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "title": {
+      "type": {
+        "type": "text"
+      },
+      "label": "Title",
+      "private": false,
+      "optional": true,
+      "position": 0
+    },
+    "description": {
+      "type": {
+        "type": "text"
+      },
+      "label": "Description",
+      "private": false,
+      "optional": true,
+      "position": 1
+    }
+  },
+  "description": "A section featuring cards with content."
+}

--- a/templates/croct/experience/saas/landing-page/configuration/cta-schema.json
+++ b/templates/croct/experience/saas/landing-page/configuration/cta-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": false,
+      "position": 1
+    },
+    "label": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Label",
+      "private": false,
+      "optional": false,
+      "position": 0
+    },
+    "appearance": {
+      "type": {
+        "type": "text",
+        "choices": {
+          "primary": {
+            "label": "Primary",
+            "default": true,
+            "position": 0
+          },
+          "secondary": {
+            "label": "Secondary",
+            "default": false,
+            "position": 1
+          }
+        }
+      },
+      "label": "Appearance",
+      "private": false,
+      "optional": false,
+      "position": 2
+    }
+  }
+}

--- a/templates/croct/experience/saas/landing-page/configuration/hero-section-schema.json
+++ b/templates/croct/experience/saas/landing-page/configuration/hero-section-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Hero section",
+  "attributes": {
+    "cta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Call to action",
+      "private": false,
+      "optional": true,
+      "position": 3,
+      "description": "The main call-to-action button."
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {}
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 2,
+      "description": "The image to display alongside the heading and tagline."
+    },
+    "heading": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Heading",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The main heading of the page."
+    },
+    "tagline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Tagline",
+      "private": false,
+      "optional": false,
+      "position": 1,
+      "description": "The tagline of the page."
+    }
+  },
+  "description": "A big section featured at the top of a page."
+}

--- a/templates/croct/experience/saas/landing-page/configuration/home-featured-topics-experience-content.en.json
+++ b/templates/croct/experience/saas/landing-page/configuration/home-featured-topics-experience-content.en.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cards": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/checklists"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/9b7f0ed2-e25a-4f63-b92d-ed6d6b5bd905"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Checklists"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Create simple checklists so you don't miss any homework."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/calendar"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e773b72d-4f36-45f6-bb14-6ae3c67b59d3"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Calendar"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Plan ahead and create an effective study plan."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/reminders"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/40f4e16a-d8e0-4f5b-a76d-ef75cd956adf"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Reminders"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Never forget projects due dates."
+              }
+            }
+          }
+        }
+      ]
+    },
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why Listo is perfect for students"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/landing-page/configuration/home-featured-topics-slot-content.en.json
+++ b/templates/croct/experience/saas/landing-page/configuration/home-featured-topics-slot-content.en.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cards": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/checklists"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/9b7f0ed2-e25a-4f63-b92d-ed6d6b5bd905"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Checklists"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Create simple checklists so you don't miss anything."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/calendar"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e773b72d-4f36-45f6-bb14-6ae3c67b59d3"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Calendar"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Plan ahead and organize your week."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/reminders"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/40f4e16a-d8e0-4f5b-a76d-ef75cd956adf"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Reminders"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Never forget important things."
+              }
+            }
+          }
+        }
+      ]
+    },
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why Listo is better"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/landing-page/configuration/home-hero-experience-content.en.json
+++ b/templates/croct/experience/saas/landing-page/configuration/home-hero-experience-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Start for free"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/5aa56d73-5e21-4ced-b9b7-146f630752e9"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for students"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for your study plan."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/landing-page/configuration/home-hero-slot-content.en.json
+++ b/templates/croct/experience/saas/landing-page/configuration/home-hero-slot-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Get started"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/88288403-0442-4cf3-84b9-0a4a3a680218"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for everyone"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for everything you need."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/landing-page/configuration/testimonials-experience-content.en.json
+++ b/templates/croct/experience/saas/landing-page/configuration/testimonials-experience-content.en.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why students love us"
+      }
+    },
+    "testimonials": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I never forget a project due date, thanks to Listo."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "John Doe"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e47cecc9-44dd-450f-8ae3-b69705366e9b"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I'm stunned by the quality of this app. It's a perfect planner."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Carol Duran"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/91dade3c-f2c8-4537-8489-0c40e97bdd5a"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Trust me, they're good. Their checklist is the best."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Alex Bobby"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/d92cab97-b052-482c-a0fa-2e2204d9f92c"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/saas/landing-page/configuration/testimonials-schema.json
+++ b/templates/croct/experience/saas/landing-page/configuration/testimonials-schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Testimonials",
+  "attributes": {
+    "title": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Title",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The title displayed at the top of the section."
+    },
+    "testimonials": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Logo",
+              "private": false,
+              "optional": true,
+              "position": 3,
+              "description": "The logo of the company the author works for."
+            },
+            "quote": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Quote",
+              "private": false,
+              "optional": false,
+              "position": 0,
+              "description": "The quote or feedback from the customer."
+            },
+            "author": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Author",
+              "private": false,
+              "optional": false,
+              "position": 1,
+              "description": "The name or title of the person providing the testimonial."
+            },
+            "headshot": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Headshot",
+              "private": false,
+              "optional": true,
+              "position": 2,
+              "description": "The headshot of the author of the testimonial."
+            }
+          }
+        },
+        "itemLabel": "Testimonial"
+      },
+      "label": "Testimonials",
+      "private": false,
+      "optional": false,
+      "position": 1
+    }
+  },
+  "description": "A section featuring testimonials."
+}

--- a/templates/croct/experience/saas/landing-page/configuration/testimonials-slot-content.en.json
+++ b/templates/croct/experience/saas/landing-page/configuration/testimonials-slot-content.en.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why they love us"
+      }
+    },
+    "testimonials": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/6245b2c3-ce4f-4d02-8f3b-e2200ab09776"
+              }
+            },
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "This is the best alternative you'll find in the market."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "John Doe"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e47cecc9-44dd-450f-8ae3-b69705366e9b"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/889f3411-116e-4db9-945a-8e6614d71b78"
+              }
+            },
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I'm stunned by the quality of this app. It's perfect!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Carol Duran"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/91dade3c-f2c8-4537-8489-0c40e97bdd5a"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/ac1067ea-820b-4a17-8854-94936151ae74"
+              }
+            },
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Trust me, they're good. Their support team is amazing."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Alex Bobby"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/d92cab97-b052-482c-a0fa-2e2204d9f92c"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/saas/landing-page/cover.png
+++ b/templates/croct/experience/saas/landing-page/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d44e866ba9572a1f508dc8290a209f589e0a77da89afd70f751756ed1b0a11f
+size 47961

--- a/templates/croct/experience/saas/landing-page/template.json5
+++ b/templates/croct/experience/saas/landing-page/template.json5
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Landing page-based experience",
+  "description": "A personalized experience based on the session's landing page.",
+  "metadata": {
+    "id": "use-case/saas/landing-page",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=landing_page"
+    },
+    "categories": ["use-case/saas"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/landing-page/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/landing-page/cover.png",
+    "installationUrl": "croct://use-case/saas/landing-page",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/landing-page/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "student-landing-page": {
+            "name": "Student landing page",
+            "criteria": "session's landingPage matches \"student\""
+          }
+        },
+        "components": {
+          "content-cards": {
+            "name": "Content cards",
+            "description": "A section featuring cards with content.",
+            "schema": "${import('./configuration/content-cards-schema.json')}"
+          },
+          "cta": {
+            "name": "CTA",
+            "description": "A call to action button.",
+            "schema": "${import('./configuration/cta-schema.json')}"
+          },
+          "testimonials": {
+            "name": "Testimonials",
+            "description": "A section featuring testimonials.",
+            "schema": "${import('./configuration/testimonials-schema.json')}"
+          },
+          "hero-section": {
+            "name": "Hero section",
+            "description": "A big section featured at the top of a page.",
+            "schema": "${import('./configuration/hero-section-schema.json')}"
+          }
+        },
+        "slots": {
+          "home-featured-topics": {
+            "name": "Home featured topics",
+            "component": "content-cards",
+            "content": {
+              "en": "${import('./configuration/home-featured-topics-slot-content.en.json')}"
+            }
+          },
+          "testimonials": {
+            "name": "Testimonials",
+            "component": "testimonials",
+            "content": {
+              "en": "${import('./configuration/testimonials-slot-content.en.json')}"
+            }
+          },
+          "home-hero": {
+            "name": "Home hero",
+            "component": "hero-section",
+            "content": {
+              "en": "${import('./configuration/home-hero-slot-content.en.json')}",
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "🎓 Student landing page",
+            "draft": true,
+            "audiences": [
+              "student-landing-page"
+            ],
+            "slots": [
+              "home-featured-topics",
+              "home-hero",
+              "testimonials"
+            ],
+            "content": {
+              "default": {
+                "home-featured-topics": {
+                  "en": "${import('./configuration/home-featured-topics-experience-content.en.json')}"
+                },
+                "home-hero": {
+                  "en": "${import('./configuration/home-hero-experience-content.en.json')}"
+                },
+                "testimonials": {
+                  "en": "${import('./configuration/testimonials-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experience/saas/linkedin-campaign/README.md
+++ b/templates/croct/experience/saas/linkedin-campaign/README.md
@@ -1,0 +1,23 @@
+# Introduction
+
+This template defines a personalized experience for SaaS visitors coming from LinkedIn paid campaigns.
+
+It leverages [UTM parameters](https://docs.croct.com/reference/cql/data-types/marketing?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=linkedin_campaign) from ad URLs to align onsite content with the visitor’s interests, creating a seamless and consistent journey from ad to landing page and beyond.
+
+## What's included
+
+This experience includes:
+
+- **Components:** CTA, content cards, hero section, and navbar
+- **Slots:** home hero section, home featured topics section, and navbar
+- **Audience:** `campaign's source is "linkedin" and campaign's content matches "business"`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=linkedin_campaign), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It allows, for instance, to add two or more campaigns to the same audience using [or](https://docs.croct.com/reference/cql/expressions/operations/logical#or), [and](https://docs.croct.com/reference/cql/expressions/operations/logical#and), [starts with](https://docs.croct.com/reference/cql/expressions/tests/string#starts-with), [ends with](https://docs.croct.com/reference/cql/expressions/tests/string#ends-with), or [matches](https://docs.croct.com/reference/cql/expressions/tests/string#matches).
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/saas/linkedin-campaign
+```

--- a/templates/croct/experience/saas/linkedin-campaign/configuration/content-cards-schema.json
+++ b/templates/croct/experience/saas/linkedin-campaign/configuration/content-cards-schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Content cards",
+  "attributes": {
+    "cards": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": {
+                "id": "cta",
+                "type": "reference"
+              },
+              "label": "Call to action",
+              "private": false,
+              "optional": true,
+              "position": 3
+            },
+            "image": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Image",
+              "private": false,
+              "optional": true,
+              "position": 0,
+              "description": "The URL or path to an illustration image."
+            },
+            "title": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Title",
+              "private": false,
+              "optional": false,
+              "position": 1,
+              "description": "The title inside the card."
+            },
+            "description": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Description",
+              "private": false,
+              "optional": true,
+              "position": 2,
+              "description": "A short description."
+            }
+          }
+        },
+        "itemLabel": "Card"
+      },
+      "label": "Cards",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "title": {
+      "type": {
+        "type": "text"
+      },
+      "label": "Title",
+      "private": false,
+      "optional": true,
+      "position": 0
+    },
+    "description": {
+      "type": {
+        "type": "text"
+      },
+      "label": "Description",
+      "private": false,
+      "optional": true,
+      "position": 1
+    }
+  },
+  "description": "A section featuring cards with content."
+}

--- a/templates/croct/experience/saas/linkedin-campaign/configuration/cta-schema.json
+++ b/templates/croct/experience/saas/linkedin-campaign/configuration/cta-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": false,
+      "position": 1
+    },
+    "label": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Label",
+      "private": false,
+      "optional": false,
+      "position": 0
+    },
+    "appearance": {
+      "type": {
+        "type": "text",
+        "choices": {
+          "primary": {
+            "label": "Primary",
+            "default": true,
+            "position": 0
+          },
+          "secondary": {
+            "label": "Secondary",
+            "default": false,
+            "position": 1
+          }
+        }
+      },
+      "label": "Appearance",
+      "private": false,
+      "optional": false,
+      "position": 2
+    }
+  }
+}

--- a/templates/croct/experience/saas/linkedin-campaign/configuration/hero-section-schema.json
+++ b/templates/croct/experience/saas/linkedin-campaign/configuration/hero-section-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Hero section",
+  "attributes": {
+    "cta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Call to action",
+      "private": false,
+      "optional": true,
+      "position": 3,
+      "description": "The main call-to-action button."
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {}
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 2,
+      "description": "The image to display alongside the heading and tagline."
+    },
+    "heading": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Heading",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The main heading of the page."
+    },
+    "tagline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Tagline",
+      "private": false,
+      "optional": false,
+      "position": 1,
+      "description": "The tagline of the page."
+    }
+  },
+  "description": "A big section featured at the top of a page."
+}

--- a/templates/croct/experience/saas/linkedin-campaign/configuration/home-featured-topics-experience-content.en.json
+++ b/templates/croct/experience/saas/linkedin-campaign/configuration/home-featured-topics-experience-content.en.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cards": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/checklists"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/9b7f0ed2-e25a-4f63-b92d-ed6d6b5bd905"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Synced checklists"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Sync checklists from multiple devices."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/calendar"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e773b72d-4f36-45f6-bb14-6ae3c67b59d3"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Shared calendar"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Simplify meeting schedule in no time."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/reminders"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/40f4e16a-d8e0-4f5b-a76d-ef75cd956adf"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Reminders"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Never miss a due date again."
+              }
+            }
+          }
+        }
+      ]
+    },
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why Listo is better for business"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/linkedin-campaign/configuration/home-featured-topics-slot-content.en.json
+++ b/templates/croct/experience/saas/linkedin-campaign/configuration/home-featured-topics-slot-content.en.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cards": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/checklists"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/9b7f0ed2-e25a-4f63-b92d-ed6d6b5bd905"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Checklists"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Create simple checklists so you don't miss anything."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/calendar"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e773b72d-4f36-45f6-bb14-6ae3c67b59d3"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Calendar"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Plan ahead and organize your week."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/reminders"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/40f4e16a-d8e0-4f5b-a76d-ef75cd956adf"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Reminders"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Never forget important things."
+              }
+            }
+          }
+        }
+      ]
+    },
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why Listo is better"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/linkedin-campaign/configuration/home-hero-experience-content.en.json
+++ b/templates/croct/experience/saas/linkedin-campaign/configuration/home-hero-experience-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/sales"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Request a demo"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/ebe676ce-f4ef-4d99-ab66-a913121d66e0"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for business"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for more productivity."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/linkedin-campaign/configuration/home-hero-slot-content.en.json
+++ b/templates/croct/experience/saas/linkedin-campaign/configuration/home-hero-slot-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Get started"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/88288403-0442-4cf3-84b9-0a4a3a680218"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for everyone"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for everything you need."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/linkedin-campaign/configuration/navbar-experience-content.en.json
+++ b/templates/croct/experience/saas/linkedin-campaign/configuration/navbar-experience-content.en.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "items": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/features"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Features"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/industries"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Industries"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/use-cases"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Use cases"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/pricing"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Pricing"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "primaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/sales"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Contact sales"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "secondary"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/linkedin-campaign/configuration/navbar-schema.json
+++ b/templates/croct/experience/saas/linkedin-campaign/configuration/navbar-schema.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Header menu",
+  "attributes": {
+    "items": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": {
+                "type": "text",
+                "format": "url"
+              },
+              "label": "Link",
+              "private": false,
+              "optional": true,
+              "position": 1,
+              "description": "The target URL of the menu item."
+            },
+            "label": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Label",
+              "private": false,
+              "optional": false,
+              "position": 0,
+              "description": "The label of the menu item."
+            }
+          }
+        },
+        "itemLabel": "Menu item"
+      },
+      "label": "Items",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "primaryCta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Primary call to action",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The primary action button of the menu."
+    },
+    "secondaryCta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Secondary call to action",
+      "private": false,
+      "optional": true,
+      "position": 1,
+      "description": "The secondary action button of the menu."
+    }
+  },
+  "description": "A section of links and CTAs featured at the top of a page."
+}

--- a/templates/croct/experience/saas/linkedin-campaign/configuration/navbar-slot-content.en.json
+++ b/templates/croct/experience/saas/linkedin-campaign/configuration/navbar-slot-content.en.json
@@ -1,0 +1,158 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "items": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/features"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Features"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/students"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "For students"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/business"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "For business"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/personal"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "For you"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "link": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://example.com/pricing"
+              }
+            },
+            "label": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Pricing"
+              }
+            }
+          }
+        }
+      ]
+    },
+    "primaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Sign up"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "secondaryCta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/sales"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "For business"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "secondary"
+          }
+        }
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/linkedin-campaign/cover.png
+++ b/templates/croct/experience/saas/linkedin-campaign/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a03ed9652f12768bf58126fe85661021b45179cf17924aba6556d5219631a15
+size 46627

--- a/templates/croct/experience/saas/linkedin-campaign/template.json5
+++ b/templates/croct/experience/saas/linkedin-campaign/template.json5
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "LinkedIn campaign experience",
+  "description": "A personalized experience based on the LinkedIn campaign associated with the session.",
+  "metadata": {
+    "id": "use-case/saas/linkedin-campaign",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=linkedin_campaign"
+    },
+    "categories": ["use-case/saas"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/linkedin-campaign/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/linkedin-campaign/cover.png",
+    "installationUrl": "croct://use-case/saas/linkedin-campaign",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/linkedin-campaign/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "business-linkedin-campaign": {
+            "name": "Business LinkedIn campaign",
+            "criteria": "campaign's source is \"linkedin\" and campaign's content matches \"business\""
+          }
+        },
+        "components": {
+          "content-cards": {
+            "name": "Content cards",
+            "description": "A section featuring cards with content.",
+            "schema": "${import('./configuration/content-cards-schema.json')}"
+          },
+          "cta": {
+            "name": "CTA",
+            "description": "A call to action button.",
+            "schema": "${import('./configuration/cta-schema.json')}"
+          },
+          "navbar": {
+            "name": "Navbar",
+            "description": "A section of links and CTAs featured at the top of a page.",
+            "schema": "${import('./configuration/navbar-schema.json')}"
+          },
+          "hero-section": {
+            "name": "Hero section",
+            "description": "A big section featured at the top of a page.",
+            "schema": "${import('./configuration/hero-section-schema.json')}"
+          }
+        },
+        "slots": {
+          "home-featured-topics": {
+            "name": "Home featured topics",
+            "component": "content-cards",
+            "content": {
+              "en": "${import('./configuration/home-featured-topics-slot-content.en.json')}"
+            }
+          },
+          "navbar": {
+            "name": "Navbar",
+            "component": "navbar",
+            "content": {
+              "en": "${import('./configuration/navbar-slot-content.en.json')}"
+            }
+          },
+          "home-hero": {
+            "name": "Home hero",
+            "component": "hero-section",
+            "content": {
+              "en": "${import('./configuration/home-hero-slot-content.en.json')}",
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "💼 Business LinkedIn campaign",
+            "draft": true,
+            "audiences": [
+              "business-linkedin-campaign"
+            ],
+            "slots": [
+              "home-featured-topics",
+              "home-hero",
+              "navbar"
+            ],
+            "content": {
+              "default": {
+                "home-featured-topics": {
+                  "en": "${import('./configuration/home-featured-topics-experience-content.en.json')}"
+                },
+                "home-hero": {
+                  "en": "${import('./configuration/home-hero-experience-content.en.json')}"
+                },
+                "navbar": {
+                  "en": "${import('./configuration/navbar-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experience/saas/marketing-campaign/README.md
+++ b/templates/croct/experience/saas/marketing-campaign/README.md
@@ -1,0 +1,23 @@
+# Introduction
+
+This template defines a personalized experience for SaaS visitors coming from a given campaign.
+
+It leverages [UTM parameters](https://docs.croct.com/reference/cql/data-types/marketing?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=instagram_campaign) from ad URLs to align onsite content with the visitor’s interests, creating a seamless and consistent journey from ad to landing page and beyond.
+
+## What's included
+
+This experience includes:
+
+- **Components:** CTA, content cards, hero section, and testimonials
+- **Slots:** home hero section, home featured topics section, and testimonials
+- **Audience:** `campaign's name matches "student"`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=marketing_campaign), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It allows, for instance, to add two or more campaigns to the same audience using [or](https://docs.croct.com/reference/cql/expressions/operations/logical#or), [and](https://docs.croct.com/reference/cql/expressions/operations/logical#and), [starts with](https://docs.croct.com/reference/cql/expressions/tests/string#starts-with), [ends with](https://docs.croct.com/reference/cql/expressions/tests/string#ends-with), or [matches](https://docs.croct.com/reference/cql/expressions/tests/string#matches).
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/saas/marketing-campaign
+```

--- a/templates/croct/experience/saas/marketing-campaign/configuration/content-cards-schema.json
+++ b/templates/croct/experience/saas/marketing-campaign/configuration/content-cards-schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Content cards",
+  "attributes": {
+    "cards": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": {
+                "id": "cta",
+                "type": "reference"
+              },
+              "label": "Call to action",
+              "private": false,
+              "optional": true,
+              "position": 3
+            },
+            "image": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Image",
+              "private": false,
+              "optional": true,
+              "position": 0,
+              "description": "The URL or path to an illustration image."
+            },
+            "title": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Title",
+              "private": false,
+              "optional": false,
+              "position": 1,
+              "description": "The title inside the card."
+            },
+            "description": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Description",
+              "private": false,
+              "optional": true,
+              "position": 2,
+              "description": "A short description."
+            }
+          }
+        },
+        "itemLabel": "Card"
+      },
+      "label": "Cards",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "title": {
+      "type": {
+        "type": "text"
+      },
+      "label": "Title",
+      "private": false,
+      "optional": true,
+      "position": 0
+    },
+    "description": {
+      "type": {
+        "type": "text"
+      },
+      "label": "Description",
+      "private": false,
+      "optional": true,
+      "position": 1
+    }
+  },
+  "description": "A section featuring cards with content."
+}

--- a/templates/croct/experience/saas/marketing-campaign/configuration/cta-schema.json
+++ b/templates/croct/experience/saas/marketing-campaign/configuration/cta-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": false,
+      "position": 1
+    },
+    "label": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Label",
+      "private": false,
+      "optional": false,
+      "position": 0
+    },
+    "appearance": {
+      "type": {
+        "type": "text",
+        "choices": {
+          "primary": {
+            "label": "Primary",
+            "default": true,
+            "position": 0
+          },
+          "secondary": {
+            "label": "Secondary",
+            "default": false,
+            "position": 1
+          }
+        }
+      },
+      "label": "Appearance",
+      "private": false,
+      "optional": false,
+      "position": 2
+    }
+  }
+}

--- a/templates/croct/experience/saas/marketing-campaign/configuration/hero-section-schema.json
+++ b/templates/croct/experience/saas/marketing-campaign/configuration/hero-section-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Hero section",
+  "attributes": {
+    "cta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Call to action",
+      "private": false,
+      "optional": true,
+      "position": 3,
+      "description": "The main call-to-action button."
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {}
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 2,
+      "description": "The image to display alongside the heading and tagline."
+    },
+    "heading": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Heading",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The main heading of the page."
+    },
+    "tagline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Tagline",
+      "private": false,
+      "optional": false,
+      "position": 1,
+      "description": "The tagline of the page."
+    }
+  },
+  "description": "A big section featured at the top of a page."
+}

--- a/templates/croct/experience/saas/marketing-campaign/configuration/home-featured-topics-experience-content.en.json
+++ b/templates/croct/experience/saas/marketing-campaign/configuration/home-featured-topics-experience-content.en.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cards": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/checklists"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/9b7f0ed2-e25a-4f63-b92d-ed6d6b5bd905"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Checklists"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Create simple checklists so you don't miss any homework."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/calendar"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e773b72d-4f36-45f6-bb14-6ae3c67b59d3"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Calendar"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Plan ahead and create an effective study plan."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/reminders"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/40f4e16a-d8e0-4f5b-a76d-ef75cd956adf"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Reminders"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Never forget projects due dates."
+              }
+            }
+          }
+        }
+      ]
+    },
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why Listo is perfect for students"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/marketing-campaign/configuration/home-featured-topics-slot-content.en.json
+++ b/templates/croct/experience/saas/marketing-campaign/configuration/home-featured-topics-slot-content.en.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cards": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/checklists"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/9b7f0ed2-e25a-4f63-b92d-ed6d6b5bd905"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Checklists"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Create simple checklists so you don't miss anything."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/calendar"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e773b72d-4f36-45f6-bb14-6ae3c67b59d3"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Calendar"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Plan ahead and organize your week."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/reminders"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/40f4e16a-d8e0-4f5b-a76d-ef75cd956adf"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Reminders"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Never forget important things."
+              }
+            }
+          }
+        }
+      ]
+    },
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why Listo is better"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/marketing-campaign/configuration/home-hero-experience-content.en.json
+++ b/templates/croct/experience/saas/marketing-campaign/configuration/home-hero-experience-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Start for free"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/5aa56d73-5e21-4ced-b9b7-146f630752e9"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for students"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for your study plan."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/marketing-campaign/configuration/home-hero-slot-content.en.json
+++ b/templates/croct/experience/saas/marketing-campaign/configuration/home-hero-slot-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Get started"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/88288403-0442-4cf3-84b9-0a4a3a680218"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for everyone"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for everything you need."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/marketing-campaign/configuration/testimonials-experience-content.en.json
+++ b/templates/croct/experience/saas/marketing-campaign/configuration/testimonials-experience-content.en.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why students love us"
+      }
+    },
+    "testimonials": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I never forget a project due date, thanks to Listo."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "John Doe"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e47cecc9-44dd-450f-8ae3-b69705366e9b"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I'm stunned by the quality of this app. It's a perfect planner."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Carol Duran"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/91dade3c-f2c8-4537-8489-0c40e97bdd5a"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Trust me, they're good. Their checklist is the best."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Alex Bobby"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/d92cab97-b052-482c-a0fa-2e2204d9f92c"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/saas/marketing-campaign/configuration/testimonials-schema.json
+++ b/templates/croct/experience/saas/marketing-campaign/configuration/testimonials-schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Testimonials",
+  "attributes": {
+    "title": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Title",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The title displayed at the top of the section."
+    },
+    "testimonials": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Logo",
+              "private": false,
+              "optional": true,
+              "position": 3,
+              "description": "The logo of the company the author works for."
+            },
+            "quote": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Quote",
+              "private": false,
+              "optional": false,
+              "position": 0,
+              "description": "The quote or feedback from the customer."
+            },
+            "author": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Author",
+              "private": false,
+              "optional": false,
+              "position": 1,
+              "description": "The name or title of the person providing the testimonial."
+            },
+            "headshot": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Headshot",
+              "private": false,
+              "optional": true,
+              "position": 2,
+              "description": "The headshot of the author of the testimonial."
+            }
+          }
+        },
+        "itemLabel": "Testimonial"
+      },
+      "label": "Testimonials",
+      "private": false,
+      "optional": false,
+      "position": 1
+    }
+  },
+  "description": "A section featuring testimonials."
+}

--- a/templates/croct/experience/saas/marketing-campaign/configuration/testimonials-slot-content.en.json
+++ b/templates/croct/experience/saas/marketing-campaign/configuration/testimonials-slot-content.en.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why they love us"
+      }
+    },
+    "testimonials": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/6245b2c3-ce4f-4d02-8f3b-e2200ab09776"
+              }
+            },
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "This is the best alternative you'll find in the market."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "John Doe"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e47cecc9-44dd-450f-8ae3-b69705366e9b"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/889f3411-116e-4db9-945a-8e6614d71b78"
+              }
+            },
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I'm stunned by the quality of this app. It's perfect!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Carol Duran"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/91dade3c-f2c8-4537-8489-0c40e97bdd5a"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/ac1067ea-820b-4a17-8854-94936151ae74"
+              }
+            },
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Trust me, they're good. Their support team is amazing."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Alex Bobby"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/d92cab97-b052-482c-a0fa-2e2204d9f92c"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/saas/marketing-campaign/cover.png
+++ b/templates/croct/experience/saas/marketing-campaign/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a6314b8d8179363c2d4ad2973f465b253420651b94652fcdba7c3a199a7b8853
+size 47946

--- a/templates/croct/experience/saas/marketing-campaign/template.json5
+++ b/templates/croct/experience/saas/marketing-campaign/template.json5
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Marketing campaign experience",
+  "description": "A personalized experience based on the marketing campaign associated with the session.",
+  "metadata": {
+    "id": "use-case/saas/marketing-campaign",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=marketing_campaign"
+    },
+    "categories": ["use-case/saas"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/marketing-campaign/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/marketing-campaign/cover.png",
+    "installationUrl": "croct://use-case/saas/marketing-campaign",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/marketing-campaign/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "student-marketing-campaign": {
+            "name": "Student marketing campaign",
+            "criteria": "campaign's name matches \"student\""
+          }
+        },
+        "components": {
+          "content-cards": {
+            "name": "Content cards",
+            "description": "A section featuring cards with content.",
+            "schema": "${import('./configuration/content-cards-schema.json')}"
+          },
+          "cta": {
+            "name": "CTA",
+            "description": "A call to action button.",
+            "schema": "${import('./configuration/cta-schema.json')}"
+          },
+          "testimonials": {
+            "name": "Testimonials",
+            "description": "A section featuring testimonials.",
+            "schema": "${import('./configuration/testimonials-schema.json')}"
+          },
+          "hero-section": {
+            "name": "Hero section",
+            "description": "A big section featured at the top of a page.",
+            "schema": "${import('./configuration/hero-section-schema.json')}"
+          }
+        },
+        "slots": {
+          "home-featured-topics": {
+            "name": "Home featured topics",
+            "component": "content-cards",
+            "content": {
+              "en": "${import('./configuration/home-featured-topics-slot-content.en.json')}"
+            }
+          },
+          "testimonials": {
+            "name": "Testimonials",
+            "component": "testimonials",
+            "content": {
+              "en": "${import('./configuration/testimonials-slot-content.en.json')}"
+            }
+          },
+          "home-hero": {
+            "name": "Home hero",
+            "component": "hero-section",
+            "content": {
+              "en": "${import('./configuration/home-hero-slot-content.en.json')}",
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "🎓 Student marketing campaign",
+            "draft": true,
+            "audiences": [
+              "student-marketing-campaign"
+            ],
+            "slots": [
+              "home-featured-topics",
+              "home-hero",
+              "testimonials"
+            ],
+            "content": {
+              "default": {
+                "home-featured-topics": {
+                  "en": "${import('./configuration/home-featured-topics-experience-content.en.json')}"
+                },
+                "home-hero": {
+                  "en": "${import('./configuration/home-hero-experience-content.en.json')}"
+                },
+                "testimonials": {
+                  "en": "${import('./configuration/testimonials-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experience/saas/search-campaign/README.md
+++ b/templates/croct/experience/saas/search-campaign/README.md
@@ -1,0 +1,27 @@
+# Introduction
+
+This template defines a personalized experience for SaaS visitors coming from paid search campaigns.
+
+It leverages [UTM parameters](https://docs.croct.com/reference/cql/data-types/marketing?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=instagram_campaign) from ad URLs to align onsite content with the visitor’s search intent, creating a seamless and consistent journey from ad to landing page and beyond.
+
+## What's included
+
+This experience includes:
+
+- **Components:** CTA, content cards, hero section, and testimonials
+- **Slots:** home hero section, home featured topics section, and testimonials
+- **Audience:** `campaign's source is "google" and campaign's term matches "student"`
+
+Custom audiences can be defined using the [Contextual Query Language (CQL)](https://docs.croct.com/reference/cql/introduction?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=search_campaign), a readable, natural-language-inspired syntax designed for flexibility and ease of use. It allows, for instance, to add two or more campaigns to the same audience using [or](https://docs.croct.com/reference/cql/expressions/operations/logical#or), [and](https://docs.croct.com/reference/cql/expressions/operations/logical#and), [starts with](https://docs.croct.com/reference/cql/expressions/tests/string#starts-with), [ends with](https://docs.croct.com/reference/cql/expressions/tests/string#ends-with), or [matches](https://docs.croct.com/reference/cql/expressions/tests/string#matches).
+
+> 💬 utm_term
+>
+> Personalization with the `campaign's term` variable requires campaigns' final URLs with the `utm_term` parameter.
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experience/saas/search-campaign
+```

--- a/templates/croct/experience/saas/search-campaign/configuration/content-cards-schema.json
+++ b/templates/croct/experience/saas/search-campaign/configuration/content-cards-schema.json
@@ -1,0 +1,85 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Content cards",
+  "attributes": {
+    "cards": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": {
+                "id": "cta",
+                "type": "reference"
+              },
+              "label": "Call to action",
+              "private": false,
+              "optional": true,
+              "position": 3
+            },
+            "image": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Image",
+              "private": false,
+              "optional": true,
+              "position": 0,
+              "description": "The URL or path to an illustration image."
+            },
+            "title": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Title",
+              "private": false,
+              "optional": false,
+              "position": 1,
+              "description": "The title inside the card."
+            },
+            "description": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Description",
+              "private": false,
+              "optional": true,
+              "position": 2,
+              "description": "A short description."
+            }
+          }
+        },
+        "itemLabel": "Card"
+      },
+      "label": "Cards",
+      "private": false,
+      "optional": false,
+      "position": 2
+    },
+    "title": {
+      "type": {
+        "type": "text"
+      },
+      "label": "Title",
+      "private": false,
+      "optional": true,
+      "position": 0
+    },
+    "description": {
+      "type": {
+        "type": "text"
+      },
+      "label": "Description",
+      "private": false,
+      "optional": true,
+      "position": 1
+    }
+  },
+  "description": "A section featuring cards with content."
+}

--- a/templates/croct/experience/saas/search-campaign/configuration/cta-schema.json
+++ b/templates/croct/experience/saas/search-campaign/configuration/cta-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": false,
+      "position": 1
+    },
+    "label": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Label",
+      "private": false,
+      "optional": false,
+      "position": 0
+    },
+    "appearance": {
+      "type": {
+        "type": "text",
+        "choices": {
+          "primary": {
+            "label": "Primary",
+            "default": true,
+            "position": 0
+          },
+          "secondary": {
+            "label": "Secondary",
+            "default": false,
+            "position": 1
+          }
+        }
+      },
+      "label": "Appearance",
+      "private": false,
+      "optional": false,
+      "position": 2
+    }
+  }
+}

--- a/templates/croct/experience/saas/search-campaign/configuration/hero-section-schema.json
+++ b/templates/croct/experience/saas/search-campaign/configuration/hero-section-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Hero section",
+  "attributes": {
+    "cta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Call to action",
+      "private": false,
+      "optional": true,
+      "position": 3,
+      "description": "The main call-to-action button."
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {}
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 2,
+      "description": "The image to display alongside the heading and tagline."
+    },
+    "heading": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Heading",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The main heading of the page."
+    },
+    "tagline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Tagline",
+      "private": false,
+      "optional": false,
+      "position": 1,
+      "description": "The tagline of the page."
+    }
+  },
+  "description": "A big section featured at the top of a page."
+}

--- a/templates/croct/experience/saas/search-campaign/configuration/home-featured-topics-experience-content.en.json
+++ b/templates/croct/experience/saas/search-campaign/configuration/home-featured-topics-experience-content.en.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cards": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/checklists"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/9b7f0ed2-e25a-4f63-b92d-ed6d6b5bd905"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Checklists"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Create simple checklists so you don't miss any homework."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/calendar"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e773b72d-4f36-45f6-bb14-6ae3c67b59d3"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Calendar"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Plan ahead and create an effective study plan."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/reminders"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/40f4e16a-d8e0-4f5b-a76d-ef75cd956adf"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Reminders"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Never forget projects due dates."
+              }
+            }
+          }
+        }
+      ]
+    },
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why Listo is perfect for students"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/search-campaign/configuration/home-featured-topics-slot-content.en.json
+++ b/templates/croct/experience/saas/search-campaign/configuration/home-featured-topics-slot-content.en.json
@@ -1,0 +1,174 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cards": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/checklists"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/9b7f0ed2-e25a-4f63-b92d-ed6d6b5bd905"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Checklists"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Create simple checklists so you don't miss anything."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/calendar"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e773b72d-4f36-45f6-bb14-6ae3c67b59d3"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Calendar"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Plan ahead and organize your week."
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "cta": {
+              "type": "structure",
+              "attributes": {
+                "link": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "https://example.com/reminders"
+                  }
+                },
+                "label": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "Learn more"
+                  }
+                },
+                "appearance": {
+                  "type": "text",
+                  "value": {
+                    "type": "static",
+                    "value": "primary"
+                  }
+                }
+              }
+            },
+            "image": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/40f4e16a-d8e0-4f5b-a76d-ef75cd956adf"
+              }
+            },
+            "title": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Reminders"
+              }
+            },
+            "description": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Never forget important things."
+              }
+            }
+          }
+        }
+      ]
+    },
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why Listo is better"
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/search-campaign/configuration/home-hero-experience-content.en.json
+++ b/templates/croct/experience/saas/search-campaign/configuration/home-hero-experience-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Start for free"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/5aa56d73-5e21-4ced-b9b7-146f630752e9"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for students"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for your study plan."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/search-campaign/configuration/home-hero-slot-content.en.json
+++ b/templates/croct/experience/saas/search-campaign/configuration/home-hero-slot-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Get started"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/88288403-0442-4cf3-84b9-0a4a3a680218"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for everyone"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for everything you need."
+      }
+    }
+  }
+}

--- a/templates/croct/experience/saas/search-campaign/configuration/testimonials-experience-content.en.json
+++ b/templates/croct/experience/saas/search-campaign/configuration/testimonials-experience-content.en.json
@@ -1,0 +1,96 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why students love us"
+      }
+    },
+    "testimonials": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I never forget a project due date, thanks to Listo."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "John Doe"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e47cecc9-44dd-450f-8ae3-b69705366e9b"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I'm stunned by the quality of this app. It's a perfect planner."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Carol Duran"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/91dade3c-f2c8-4537-8489-0c40e97bdd5a"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Trust me, they're good. Their checklist is the best."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Alex Bobby"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/d92cab97-b052-482c-a0fa-2e2204d9f92c"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/saas/search-campaign/configuration/testimonials-schema.json
+++ b/templates/croct/experience/saas/search-campaign/configuration/testimonials-schema.json
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Testimonials",
+  "attributes": {
+    "title": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Title",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The title displayed at the top of the section."
+    },
+    "testimonials": {
+      "type": {
+        "type": "list",
+        "items": {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Logo",
+              "private": false,
+              "optional": true,
+              "position": 3,
+              "description": "The logo of the company the author works for."
+            },
+            "quote": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Quote",
+              "private": false,
+              "optional": false,
+              "position": 0,
+              "description": "The quote or feedback from the customer."
+            },
+            "author": {
+              "type": {
+                "type": "text",
+                "minimumLength": 1
+              },
+              "label": "Author",
+              "private": false,
+              "optional": false,
+              "position": 1,
+              "description": "The name or title of the person providing the testimonial."
+            },
+            "headshot": {
+              "type": {
+                "id": "@croct/file",
+                "type": "reference",
+                "properties": {}
+              },
+              "label": "Headshot",
+              "private": false,
+              "optional": true,
+              "position": 2,
+              "description": "The headshot of the author of the testimonial."
+            }
+          }
+        },
+        "itemLabel": "Testimonial"
+      },
+      "label": "Testimonials",
+      "private": false,
+      "optional": false,
+      "position": 1
+    }
+  },
+  "description": "A section featuring testimonials."
+}

--- a/templates/croct/experience/saas/search-campaign/configuration/testimonials-slot-content.en.json
+++ b/templates/croct/experience/saas/search-campaign/configuration/testimonials-slot-content.en.json
@@ -1,0 +1,117 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "title": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Why they love us"
+      }
+    },
+    "testimonials": {
+      "type": "list",
+      "items": [
+        {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/6245b2c3-ce4f-4d02-8f3b-e2200ab09776"
+              }
+            },
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "This is the best alternative you'll find in the market."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "John Doe"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/e47cecc9-44dd-450f-8ae3-b69705366e9b"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/889f3411-116e-4db9-945a-8e6614d71b78"
+              }
+            },
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "I'm stunned by the quality of this app. It's perfect!"
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Carol Duran"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/91dade3c-f2c8-4537-8489-0c40e97bdd5a"
+              }
+            }
+          }
+        },
+        {
+          "type": "structure",
+          "attributes": {
+            "logo": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/ac1067ea-820b-4a17-8854-94936151ae74"
+              }
+            },
+            "quote": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Trust me, they're good. Their support team is amazing."
+              }
+            },
+            "author": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "Alex Bobby"
+              }
+            },
+            "headshot": {
+              "type": "text",
+              "value": {
+                "type": "static",
+                "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/d92cab97-b052-482c-a0fa-2e2204d9f92c"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/templates/croct/experience/saas/search-campaign/cover.png
+++ b/templates/croct/experience/saas/search-campaign/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ae7ef2e46e925fb64ed1d1e3cb6405a57ed113e34fa27c0ca8a552d1f07c2335
+size 47904

--- a/templates/croct/experience/saas/search-campaign/template.json5
+++ b/templates/croct/experience/saas/search-campaign/template.json5
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Search campaign experience",
+  "description": "A personalized experience based on the search campaign associated with the session.",
+  "metadata": {
+    "id": "use-case/saas/search-campaign",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.saas&utm_content=search_campaign"
+    },
+    "categories": ["use-case/saas"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/search-campaign/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/search-campaign/cover.png",
+    "installationUrl": "croct://use-case/saas/search-campaign",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experience/saas/search-campaign/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "student-google-campaign": {
+            "name": "Student Google campaign",
+            "criteria": "campaign's source is \"google\" and campaign's term matches \"student\""
+          }
+        },
+        "components": {
+          "content-cards": {
+            "name": "Content cards",
+            "description": "A section featuring cards with content.",
+            "schema": "${import('./configuration/content-cards-schema.json')}"
+          },
+          "cta": {
+            "name": "CTA",
+            "description": "A call to action button.",
+            "schema": "${import('./configuration/cta-schema.json')}"
+          },
+          "testimonials": {
+            "name": "Testimonials",
+            "description": "A section featuring testimonials.",
+            "schema": "${import('./configuration/testimonials-schema.json')}"
+          },
+          "hero-section": {
+            "name": "Hero section",
+            "description": "A big section featured at the top of a page.",
+            "schema": "${import('./configuration/hero-section-schema.json')}"
+          }
+        },
+        "slots": {
+          "home-featured-topics": {
+            "name": "Home featured topics",
+            "component": "content-cards",
+            "content": {
+              "en": "${import('./configuration/home-featured-topics-slot-content.en.json')}"
+            }
+          },
+          "testimonials": {
+            "name": "Testimonials",
+            "component": "testimonials",
+            "content": {
+              "en": "${import('./configuration/testimonials-slot-content.en.json')}"
+            }
+          },
+          "home-hero": {
+            "name": "Home hero",
+            "component": "hero-section",
+            "content": {
+              "en": "${import('./configuration/home-hero-slot-content.en.json')}",
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "🎓 Student Google campaign",
+            "draft": true,
+            "audiences": [
+              "student-google-campaign"
+            ],
+            "slots": [
+              "home-featured-topics",
+              "home-hero",
+              "testimonials"
+            ],
+            "content": {
+              "default": {
+                "home-featured-topics": {
+                  "en": "${import('./configuration/home-featured-topics-experience-content.en.json')}"
+                },
+                "home-hero": {
+                  "en": "${import('./configuration/home-hero-experience-content.en.json')}"
+                },
+                "testimonials": {
+                  "en": "${import('./configuration/testimonials-experience-content.en.json')}"
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experience successfully created."
+    }
+  ]
+}

--- a/templates/croct/experiment/all-users/README.md
+++ b/templates/croct/experiment/all-users/README.md
@@ -1,0 +1,19 @@
+# Introduction
+
+This template creates an experiment for all users who browse the website and splits them into two variants, each with 50% of the traffic.
+
+## What's included
+
+This experience includes:
+
+- **Components:** CTA and hero section
+- **Slots:** home hero section
+- **Experiment:** 2 variants with 50/50 split
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experiment/all-users
+```

--- a/templates/croct/experiment/all-users/configuration/cta-schema.json
+++ b/templates/croct/experiment/all-users/configuration/cta-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": false,
+      "position": 1
+    },
+    "label": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Label",
+      "private": false,
+      "optional": false,
+      "position": 0
+    },
+    "appearance": {
+      "type": {
+        "type": "text",
+        "choices": {
+          "primary": {
+            "label": "Primary",
+            "default": true,
+            "position": 0
+          },
+          "secondary": {
+            "label": "Secondary",
+            "default": false,
+            "position": 1
+          }
+        }
+      },
+      "label": "Appearance",
+      "private": false,
+      "optional": false,
+      "position": 2
+    }
+  }
+}

--- a/templates/croct/experiment/all-users/configuration/hero-section-schema.json
+++ b/templates/croct/experiment/all-users/configuration/hero-section-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Hero section",
+  "attributes": {
+    "cta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Call to action",
+      "private": false,
+      "optional": true,
+      "position": 3,
+      "description": "The main call-to-action button."
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {}
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 2,
+      "description": "The image to display alongside the heading and tagline."
+    },
+    "heading": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Heading",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The main heading of the page."
+    },
+    "tagline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Tagline",
+      "private": false,
+      "optional": false,
+      "position": 1,
+      "description": "The tagline of the page."
+    }
+  },
+  "description": "A big section featured at the top of a page."
+}

--- a/templates/croct/experiment/all-users/configuration/home-hero-experiment-content.en.json
+++ b/templates/croct/experiment/all-users/configuration/home-hero-experiment-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Start for free"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/88288403-0442-4cf3-84b9-0a4a3a680218"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for everyone"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for everything you need."
+      }
+    }
+  }
+}

--- a/templates/croct/experiment/all-users/configuration/home-hero-slot-content.en.json
+++ b/templates/croct/experiment/all-users/configuration/home-hero-slot-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Get started"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/88288403-0442-4cf3-84b9-0a4a3a680218"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for everyone"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for everything you need."
+      }
+    }
+  }
+}

--- a/templates/croct/experiment/all-users/cover.png
+++ b/templates/croct/experiment/all-users/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:78a9a02d32c04eea5140e2b1abc04727f1ef54316d6e64b8df08f37c62798451
+size 39230

--- a/templates/croct/experiment/all-users/template.json5
+++ b/templates/croct/experiment/all-users/template.json5
@@ -1,0 +1,106 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Simple AB test",
+  "description": "A simple experiment for all users.",
+  "metadata": {
+    "id": "use-case/experiment/all-users",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.experiment&utm_content=all_users"
+    },
+    "categories": [
+      "use-case/experiment"
+    ],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experiment/all-users/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experiment/all-users/cover.png",
+    "installationUrl": "croct://use-case/experiment/all-users",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experiment/all-users/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "all-users": {
+            "name": "All users",
+            "criteria": "true"
+          }
+        },
+        "components": {
+          "cta": {
+            "name": "CTA",
+            "description": "A call to action button.",
+            "schema": "${import('./configuration/cta-schema.json')}"
+          },
+          "hero-section": {
+            "name": "Hero section",
+            "description": "A big section featured at the top of a page.",
+            "schema": "${import('./configuration/hero-section-schema.json')}"
+          }
+        },
+        "slots": {
+          "home-hero": {
+            "name": "Home hero",
+            "component": "hero-section",
+            "content": {
+              "en": "${import('./configuration/home-hero-slot-content.en.json')}",
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "🧪 Experiment for all users",
+            "draft": true,
+            "audiences": [
+              "all-users"
+            ],
+            "slots": [
+              "home-hero"
+            ],
+            "content": {
+              "default": {}
+            },
+            "experiment": {
+              "name": "Home hero CTA label",
+              "goalId": "sign-up",
+              "crossDevice": false,
+              "traffic": 1,
+              "variants": [
+                {
+                  "name": "Get started",
+                  "content": {
+                    "default": {
+                      "home-hero": {
+                        "en": "${import('./configuration/home-hero-slot-content.en.json')}"
+                      }
+                    }
+                  },
+                  "baseline": true,
+                  "allocation": 500
+                },
+                {
+                  "name": "Start for free",
+                  "content": {
+                    "default": {
+                      "home-hero": {
+                        "en": "${import('./configuration/home-hero-experiment-content.en.json')}"
+                      }
+                    }
+                  },
+                  "baseline": false,
+                  "allocation": 500
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experiment successfully created."
+    }
+  ]
+}

--- a/templates/croct/experiment/segmented/README.md
+++ b/templates/croct/experiment/segmented/README.md
@@ -1,0 +1,20 @@
+# Introduction
+
+This template creates a segmented experiment for new users who browse the website and splits them into two variants, each with 50% of the traffic.
+
+## What's included
+
+This experience includes:
+
+- **Components:** CTA and hero section
+- **Slots:** home hero section
+- **Experiment:** 2 variants with 50/50 split
+- **Audience:** `user is not returning`
+
+## Usage
+
+To create a new experience using this template, run:
+
+```js-pm
+croct@latest use croct://experiment/segmented-users
+```

--- a/templates/croct/experiment/segmented/configuration/cta-schema.json
+++ b/templates/croct/experiment/segmented/configuration/cta-schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "attributes": {
+    "link": {
+      "type": {
+        "type": "text",
+        "format": "url"
+      },
+      "label": "Link",
+      "private": false,
+      "optional": false,
+      "position": 1
+    },
+    "label": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Label",
+      "private": false,
+      "optional": false,
+      "position": 0
+    },
+    "appearance": {
+      "type": {
+        "type": "text",
+        "choices": {
+          "primary": {
+            "label": "Primary",
+            "default": true,
+            "position": 0
+          },
+          "secondary": {
+            "label": "Secondary",
+            "default": false,
+            "position": 1
+          }
+        }
+      },
+      "label": "Appearance",
+      "private": false,
+      "optional": false,
+      "position": 2
+    }
+  }
+}

--- a/templates/croct/experiment/segmented/configuration/hero-section-schema.json
+++ b/templates/croct/experiment/segmented/configuration/hero-section-schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content-schema.json",
+  "type": "structure",
+  "title": "Hero section",
+  "attributes": {
+    "cta": {
+      "type": {
+        "id": "cta",
+        "type": "reference"
+      },
+      "label": "Call to action",
+      "private": false,
+      "optional": true,
+      "position": 3,
+      "description": "The main call-to-action button."
+    },
+    "image": {
+      "type": {
+        "id": "@croct/file",
+        "type": "reference",
+        "properties": {}
+      },
+      "label": "Image",
+      "private": false,
+      "optional": false,
+      "position": 2,
+      "description": "The image to display alongside the heading and tagline."
+    },
+    "heading": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Heading",
+      "private": false,
+      "optional": false,
+      "position": 0,
+      "description": "The main heading of the page."
+    },
+    "tagline": {
+      "type": {
+        "type": "text",
+        "minimumLength": 1
+      },
+      "label": "Tagline",
+      "private": false,
+      "optional": false,
+      "position": 1,
+      "description": "The tagline of the page."
+    }
+  },
+  "description": "A big section featured at the top of a page."
+}

--- a/templates/croct/experiment/segmented/configuration/home-hero-experiment-content.en.json
+++ b/templates/croct/experiment/segmented/configuration/home-hero-experiment-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Start for free"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/88288403-0442-4cf3-84b9-0a4a3a680218"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for everyone"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for everything you need."
+      }
+    }
+  }
+}

--- a/templates/croct/experiment/segmented/configuration/home-hero-slot-content.en.json
+++ b/templates/croct/experiment/segmented/configuration/home-hero-slot-content.en.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/content.json",
+  "type": "structure",
+  "attributes": {
+    "cta": {
+      "type": "structure",
+      "attributes": {
+        "link": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "https://example.com/signup"
+          }
+        },
+        "label": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "Get started"
+          }
+        },
+        "appearance": {
+          "type": "text",
+          "value": {
+            "type": "static",
+            "value": "primary"
+          }
+        }
+      }
+    },
+    "image": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "https://cdn.croct.io/workspace/customer-assets/bac910ff-a18e-4ca5-bdd0-155139967ea4/88288403-0442-4cf3-84b9-0a4a3a680218"
+      }
+    },
+    "heading": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Listo for everyone"
+      }
+    },
+    "tagline": {
+      "type": "text",
+      "value": {
+        "type": "static",
+        "value": "Note-taking app for everything you need."
+      }
+    }
+  }
+}

--- a/templates/croct/experiment/segmented/cover.png
+++ b/templates/croct/experiment/segmented/cover.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b02fdc21a9339ad4ffd5b7368ecf8c3a77a6adc08f61c0ef65fa5555ac0154e
+size 42327

--- a/templates/croct/experiment/segmented/template.json5
+++ b/templates/croct/experiment/segmented/template.json5
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
+  "title": "Segmented AB test",
+  "description": "A segmented experiment for new users.",
+  "metadata": {
+    "id": "use-case/experiment/segmented",
+    "author": {
+      "name": "Croct",
+      "avatarUrl": "https://github.com/croct-tech.png",
+      "websiteUrl": "https://croct.com?utm_medium=cli&utm_source=template&utm_campaign=00000000.CO.DE.experiment&utm_content=segmented"
+    },
+    "categories": ["use-case/experiment"],
+    "sourceUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experiment/segmented/template.json5",
+    "coverImageUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experiment/segmented/cover.png",
+    "installationUrl": "croct://use-case/experiment/segmented",
+    "documentationUrl": "https://github.com/croct-tech/templates/blob/master/templates/croct/experiment/segmented/README.md"
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "audiences": {
+          "new-users": {
+            "name": "New users",
+            "criteria": "user is not returning"
+          }
+        },
+        "components": {
+          "cta": {
+            "name": "CTA",
+            "description": "A call to action button.",
+            "schema": "${import('./configuration/cta-schema.json')}"
+          },
+          "hero-section": {
+            "name": "Hero section",
+            "description": "A big section featured at the top of a page.",
+            "schema": "${import('./configuration/hero-section-schema.json')}"
+          }
+        },
+        "slots": {
+          "home-hero": {
+            "name": "Home hero",
+            "component": "hero-section",
+            "content": {
+              "en": "${import('./configuration/home-hero-slot-content.en.json')}",
+            }
+          }
+        },
+        "experiences": [
+          {
+            "name": "🧪 Experiment for new users",
+            "draft": true,
+            "audiences": [
+              "new-users"
+            ],
+            "slots": [
+              "home-hero"
+            ],
+            "content": {
+              "default": {}
+            },
+            "experiment": {
+              "name": "Home hero CTA label",
+              "goalId": "sign-up",
+              "crossDevice": false,
+              "traffic": 1,
+              "variants": [
+                {
+                  "name": "Get started",
+                  "content": {
+                    "default": {
+                      "home-hero": {
+                        "en": "${import('./configuration/home-hero-slot-content.en.json')}"
+                      }
+                    }
+                  },
+                  "baseline": true,
+                  "allocation": 500
+                },
+                {
+                  "name": "Start for free",
+                  "content": {
+                    "default": {
+                      "home-hero": {
+                        "en": "${import('./configuration/home-hero-experiment-content.en.json')}"
+                      }
+                    }
+                  },
+                  "baseline": false,
+                  "allocation": 500
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "print",
+      "semantics": "success",
+      "message": "Experiment successfully created."
+    }
+  ]
+}

--- a/templates/shadcn-ui/project/template.json5
+++ b/templates/shadcn-ui/project/template.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
   "title": "Next.js + Shadcn UI project",
-  "description": "A template for bootstrapping a new project with Next.js and shadcn.",
+  "description": "A template for bootstrapping a new project with Next.js and Shadcn UI.",
   "metadata": {
     "id": "boilerplate/starter/shadcn-project",
     "author": {


### PR DESCRIPTION
This PR adds 14 experience templates (7 for e-commerce and 7 for SaaS), plus 2 experiment templates. The template metadata will be added later.