### PR TITLE
Fix template directory logic

### DIFF
--- a/templates/shadcn-ui/croct/template.json5
+++ b/templates/shadcn-ui/croct/template.json5
@@ -90,10 +90,6 @@
                 "router": "${options.router}",
               }
             },
-            {
-              "name": "change-directory",
-              "path": "${this.projectName}"
-            }
           ],
           "else": {
             "name": "fail",

--- a/templates/shadcn-ui/project/template.json5
+++ b/templates/shadcn-ui/project/template.json5
@@ -65,55 +65,44 @@
      Issue: https://github.com/shadcn-ui/ui/issues/6767
    */
     {
-      "name": "change-directory",
-      "path": "${options.name}"
-    },
-    {
-      "name": "try",
-      "action": {
-        "name": "execute-package",
-        "package": "shadcn@latest",
-        "runner": "npm",
-        "arguments": ["init"],
-        "interactions": [
-          {
-            "when": "Would you like to start a new project?",
-            "then": ["[enter]"]
-          },
-          {
-            "when": "What is your project named?",
-            "then": ["${options.name}", "[enter]"]
-          },
-          {
-            "when": "You need to create a components.json file to add components. Proceed?",
-            "then": ["[enter]"]
-          },
-          {
-            "when": "How would you like to proceed?",
-            "then": ["[enter]"]
-          },
-          {
-            "when": "Which style would you like to use?",
-            "then": ["[enter]"]
-          },
-          {
-            "when": "Which color would you like to use as the base color?",
-            "then": ["[enter]"]
-          },
-          {
-            "when": "Would you like to use CSS variables for theming?",
-            "then": ["[enter]"]
-          },
-          {
-            "when": "You may now add components",
-            "final": true,
-          }
-        ]
-      },
-      "finally": {
-        "name": "change-directory",
-        "path": ".."
-      }
+      "name": "execute-package",
+      "package": "shadcn@latest",
+      "runner": "npm",
+      "arguments": ["init"],
+      "interactions": [
+        {
+          "when": "Would you like to start a new project?",
+          "then": ["[enter]"]
+        },
+        {
+          "when": "What is your project named?",
+          "then": ["${options.name}", "[enter]"]
+        },
+        {
+          "when": "You need to create a components.json file to add components. Proceed?",
+          "then": ["[enter]"]
+        },
+        {
+          "when": "How would you like to proceed?",
+          "then": ["[enter]"]
+        },
+        {
+          "when": "Which style would you like to use?",
+          "then": ["[enter]"]
+        },
+        {
+          "when": "Which color would you like to use as the base color?",
+          "then": ["[enter]"]
+        },
+        {
+          "when": "Would you like to use CSS variables for theming?",
+          "then": ["[enter]"]
+        },
+        {
+          "when": "Project initialization completed",
+          "final": true,
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
This PR removes the logic that previously handled entering the project directory when creating a new project from a template. Since #35, the Next.js Croct template already handles this step automatically. Keeping the old logic caused the template to attempt entering the directory twice, resulting in errors.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings