### PR TITLE
Add default for verified flag

### DIFF
--- a/bin/cli.ts
+++ b/bin/cli.ts
@@ -320,7 +320,7 @@ async function createTemplateUpdate(options: UpdateOptions): Promise<TemplateUpd
                 : undefined,
             installationUrl: metadata.installationUrl,
             sourceUrl: metadata.sourceUrl,
-            verified: metadata.verified,
+            verified: metadata.verified ?? false,
             relatedTemplates: metadata.relatedTemplates ?? [],
             options: Object.entries(template.options ?? []).map(
                 ([name, definition]) => ({


### PR DESCRIPTION
## Summary
Since template publication doesn't overwrite the entire document (to preserve fields like popularity, publication date, etc), flags such as `verified` can unintentionally revert to a previous state if they were once set and later unset.

To address this, this PR explicitly sets these flags to `false` when not specified in the update payload.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings