### PR TITLE
Refactor Magic UI components to use extensions

### DIFF
--- a/templates/magic-ui/component/animated-list/configuration/animated-list-schema.json
+++ b/templates/magic-ui/component/animated-list/configuration/animated-list-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/template-content-schema.json",
   "type": "structure",
-  "title": "Magic UI - Animated list",
+  "title": "Animated list",
   "attributes": {
     "delay": {
       "type": {

--- a/templates/magic-ui/component/animated-list/extension.json5
+++ b/templates/magic-ui/component/animated-list/extension.json5
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Animated list customization",
+  "description": "A customization template for the animated list component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-animated-list": {
+            "name": "Magic UI - Animated list",
+            "description": "A list with animations to display notifications, updates, or events.",
+            "schema": "${import('./configuration/animated-list-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-animated-list": {
+            "name": "Magic UI - Animated list",
+            "component": "magic-ui-animated-list",
+            "content": {
+              "en": "${import('./configuration/animated-list-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-animated-list": {
+            "id": "${options.slotId}",
+            "version": "${options.slotVersion}"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/animated-list/template.json5
+++ b/templates/magic-ui/component/animated-list/template.json5
@@ -56,7 +56,7 @@
         "components": [
           "notification-list.tsx"
         ],
-        "extension": "magic-ui://component/animated-list/extension.json5",
+        "extension": "magic-ui://component/animated-list/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/animated-list/template.json5
+++ b/templates/magic-ui/component/animated-list/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Animated list",
+  "title": "Animated list",
   "description": "A list with animations to display notifications, updates, or events.",
   "metadata": {
     "id": "library/magic-ui/animated-list",

--- a/templates/magic-ui/component/animated-list/template.json5
+++ b/templates/magic-ui/component/animated-list/template.json5
@@ -53,45 +53,10 @@
         "id": "animated-list",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "notification-list.tsx"
         ],
-        "action": {
-          "name": "run",
-          "actions": [
-            {
-              "name": "create-resource",
-              "resources": {
-                "components": {
-                  "magic-ui-animated-list": {
-                    "name": "Magic UI - Animated list",
-                    "description": "A list with animations to display notifications, updates, or events.",
-                    "schema": "${import('./configuration/animated-list-schema.json')}"
-                  }
-                },
-                "slots": {
-                  "magic-ui-animated-list": {
-                    "name": "Magic UI - Animated list",
-                    "component": "magic-ui-animated-list",
-                    "content": {
-                      "en": "${import('./configuration/animated-list-content.en.json')}"
-                    }
-                  }
-                }
-              },
-              "result": {
-                "slots": {
-                  "magic-ui-animated-list": {
-                    "id": "slotId",
-                    "version": "slotVersion"
-                  }
-                }
-              }
-            }
-          ]
-        }
+        "extension": "magic-ui://component/animated-list/extension.json5",
       }
     }
   ]

--- a/templates/magic-ui/component/avatar-circles/configuration/avatar-circles-schema.json
+++ b/templates/magic-ui/component/avatar-circles/configuration/avatar-circles-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/template-content-schema.json",
   "type": "structure",
-  "title": "Magic UI - Avatar circles",
+  "title": "Avatar circles",
   "attributes": {
     "avatars": {
       "type": {

--- a/templates/magic-ui/component/avatar-circles/extension.json5
+++ b/templates/magic-ui/component/avatar-circles/extension.json5
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Avatar circles customization",
+  "description": "A customization template for the avatar circles component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-avatar-circles": {
+            "name": "Magic UI - Avatar circles",
+            "description": "A list of avatars to represent people, brands, or tools.",
+            "schema": "${import('./configuration/avatar-circles-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-avatar-circles": {
+            "name": "Magic UI - Avatar circles",
+            "component": "magic-ui-avatar-circles",
+            "content": {
+              "en": "${import('./configuration/avatar-circles-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-avatar-circles": {
+            "id": "slotId",
+            "version": "slotVersion"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/avatar-circles/template.json5
+++ b/templates/magic-ui/component/avatar-circles/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Avatar circles",
+  "title": "Avatar circles",
   "description": "A list of avatars to represent people, brands, or tools.",
   "metadata": {
     "id": "library/magic-ui/avatar-circles",

--- a/templates/magic-ui/component/avatar-circles/template.json5
+++ b/templates/magic-ui/component/avatar-circles/template.json5
@@ -52,45 +52,10 @@
         "id": "avatar-circles",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "avatar-stack.tsx"
         ],
-        "action": {
-          "name": "run",
-          "actions": [
-            {
-              "name": "create-resource",
-              "resources": {
-                "components": {
-                  "magic-ui-avatar-circles": {
-                    "name": "Magic UI - Avatar circles",
-                    "description": "A list of avatars to represent people, brands, or tools.",
-                    "schema": "${import('./configuration/avatar-circles-schema.json')}"
-                  }
-                },
-                "slots": {
-                  "magic-ui-avatar-circles": {
-                    "name": "Magic UI - Avatar circles",
-                    "component": "magic-ui-avatar-circles",
-                    "content": {
-                      "en": "${import('./configuration/avatar-circles-content.en.json')}"
-                    }
-                  }
-                }
-              },
-              "result": {
-                "slots": {
-                  "magic-ui-avatar-circles": {
-                    "id": "slotId",
-                    "version": "slotVersion"
-                  }
-                }
-              }
-            }
-          ]
-        }
+        "extension": "magic-ui://component/avatar-circles/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/bento-grid/configuration/bento-grid-schema.json
+++ b/templates/magic-ui/component/bento-grid/configuration/bento-grid-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/template-content-schema.json",
   "type": "structure",
-  "title": "Magic UI - Bento grid",
+  "title": "Bento grid",
   "attributes": {
     "cards": {
       "type": {

--- a/templates/magic-ui/component/bento-grid/extension.json5
+++ b/templates/magic-ui/component/bento-grid/extension.json5
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Bento grid customization",
+  "description": "A customization template for the bento grid component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-bento-grid": {
+            "name": "Magic UI - Bento grid",
+            "description": "A modular grid layout for featuring content blocks, use cases, or product highlights.",
+            "schema": "${import('./configuration/bento-grid-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-bento-grid": {
+            "name": "Magic UI - Bento grid",
+            "component": "magic-ui-bento-grid",
+            "content": {
+              "en": "${import('./configuration/bento-grid-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-bento-grid": {
+            "id": "slotId",
+            "version": "slotVersion"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/bento-grid/template.json5
+++ b/templates/magic-ui/component/bento-grid/template.json5
@@ -57,45 +57,10 @@
         "id": "bento-grid",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "feature-grid.tsx"
         ],
-        "action": {
-          "name": "run",
-          "actions": [
-            {
-              "name": "create-resource",
-              "resources": {
-                "components": {
-                  "magic-ui-bento-grid": {
-                    "name": "Magic UI - Bento grid",
-                    "description": "A modular grid layout for featuring content blocks, use cases, or product highlights.",
-                    "schema": "${import('./configuration/bento-grid-schema.json')}"
-                  }
-                },
-                "slots": {
-                  "magic-ui-bento-grid": {
-                    "name": "Magic UI - Bento grid",
-                    "component": "magic-ui-bento-grid",
-                    "content": {
-                      "en": "${import('./configuration/bento-grid-content.en.json')}"
-                    }
-                  }
-                }
-              },
-              "result": {
-                "slots": {
-                  "magic-ui-bento-grid": {
-                    "id": "slotId",
-                    "version": "slotVersion"
-                  }
-                }
-              }
-            }
-          ]
-        }
+        "extension": "magic-ui://component/bento-grid/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/bento-grid/template.json5
+++ b/templates/magic-ui/component/bento-grid/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Bento grid",
+  "title": "Bento grid",
   "description": "A modular grid layout for featuring content blocks, use cases, or product highlights.",
   "metadata": {
     "id": "library/magic-ui/bento-grid",

--- a/templates/magic-ui/component/code-comparison/configuration/code-comparison-schema.json
+++ b/templates/magic-ui/component/code-comparison/configuration/code-comparison-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/template-content-schema.json",
   "type": "structure",
-  "title": "Magic UI - Code comparison",
+  "title": "Code comparison",
   "attributes": {
     "beforeCode": {
       "type": {

--- a/templates/magic-ui/component/code-comparison/extension.json5
+++ b/templates/magic-ui/component/code-comparison/extension.json5
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Code comparison customization",
+  "description": "A customization template for the code comparison component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "add-dependency",
+      "dependencies": [
+        "@shikijs/transformers"
+      ]
+    },
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-code-comparison": {
+            "name": "Magic UI - Code comparison",
+            "description": "A side-by-side code block layout for comparing implementations or versions.",
+            "schema": "${import('./configuration/code-comparison-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-code-comparison": {
+            "name": "Magic UI - Code comparison",
+            "component": "magic-ui-code-comparison",
+            "content": {
+              "en": "${import('./configuration/code-comparison-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-code-comparison": {
+            "id": "slotId",
+            "version": "slotVersion"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/code-comparison/template.json5
+++ b/templates/magic-ui/component/code-comparison/template.json5
@@ -57,51 +57,10 @@
         "id": "code-comparison",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "code-diff-pane.tsx"
         ],
-        "action": {
-          "name": "run",
-          "actions": [
-            {
-              "name": "add-dependency",
-              "dependencies": [
-                "@shikijs/transformers"
-              ]
-            },
-            {
-              "name": "create-resource",
-              "resources": {
-                "components": {
-                  "magic-ui-code-comparison": {
-                    "name": "Magic UI - Code comparison",
-                    "description": "A side-by-side code block layout for comparing implementations or versions.",
-                    "schema": "${import('./configuration/code-comparison-schema.json')}"
-                  }
-                },
-                "slots": {
-                  "magic-ui-code-comparison": {
-                    "name": "Magic UI - Code comparison",
-                    "component": "magic-ui-code-comparison",
-                    "content": {
-                      "en": "${import('./configuration/code-comparison-content.en.json')}"
-                    }
-                  }
-                }
-              },
-              "result": {
-                "slots": {
-                  "magic-ui-code-comparison": {
-                    "id": "slotId",
-                    "version": "slotVersion"
-                  }
-                }
-              }
-            }
-          ]
-        }
+        "extension": "magic-ui://component/code-comparison/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/code-comparison/template.json5
+++ b/templates/magic-ui/component/code-comparison/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Code comparison",
+  "title": "Code comparison",
   "description": "A side-by-side code block layout for comparing implementations or versions.",
   "metadata": {
     "id": "library/magic-ui/code-comparison",

--- a/templates/magic-ui/component/component/README.md
+++ b/templates/magic-ui/component/component/README.md
@@ -3,8 +3,8 @@
 This template creates a reusable setup for importing [Magic UI](https://magicui.design?utm_source=croct) components, fully integrated
 with Croct for content management, AB testing, and real-time personalization.
 
-It supports downloading code, configuring slots, and extending functionality with additional
-custom actions. If the current directory does not contain a project, the template creates a new one using [Next.js](https://nextjs.org/?utm_source=croct).
+It supports downloading code, configuring slots, and extending functionality with additional actions. 
+If the current directory does not contain a project, the template creates a new one using [Next.js](https://nextjs.org/?utm_source=croct).
 
 ## Usage
 
@@ -19,52 +19,19 @@ Here is an example of how to use this template:
     "slotId": "slotId",
     "slotVersion": "slotVersion",
     "components": ["notification-list.tsx"],
-    "action": {
-      "name": "run",
-      "actions": [
-        {
-          "name": "create-resource",
-          "resources": {
-            "components": {
-              "magic-ui-animated-list": {
-                "name": "Magic UI – Animated list",
-                "description": "A list that animates items with staggered timing, perfect for showcasing notifications or events on your landing page.",
-                "schema": "${import('./configuration/animated-list-schema.json')}"
-              }
-            },
-            "slots": {
-              "magic-ui-animated-list": {
-                "name": "Magic UI – Animated list",
-                "component": "magic-ui-animated-list",
-                "content": {
-                  "en": "${import('./configuration/animated-list-content.en.json')}"
-                }
-              }
-            }
-          },
-          "result": {
-            "slots": {
-              "magic-ui-animated-list": {
-                "id": "slotId",
-                "version": "slotVersion"
-              }
-            }
-          }
-        }
-      ]
-    }
+    "extension": "magic-ui://component/marquee/extension.json5"
   }
 }
 ```
 
 ## Options
 
-| Option        | Description                                                                     | Type        | Required | Default  |
-|---------------|---------------------------------------------------------------------------------|-------------|----------|----------|
-| `id`          | A unique identifier for the Magic UI component, as defined in the registry.     | `string`    | Yes      | –        |
-| `version`     | The version of Next.js to use when generating a new project.                    | `string`    | No       | `latest` |
-| `router`      | The router format to use (`app` or `page`).                                     | `string`    | No       | `app`    |
-| `slotId`      | The variable name that holds the slot ID created or used by the template.       | `reference` | Yes      | –        |
-| `slotVersion` | The variable name that holds the version of the slot.                           | `reference` | Yes      | –        |
-| `components`  | A list of Magic UI component files to download and include in the project.      | `array`     | No       | –        |
-| `action`      | An optional block of actions to run as part of the setup (e.g., slot creation). | `object`    | No       | –        |
+| Option        | Description                                                                 | Required | Default  |
+|---------------|-----------------------------------------------------------------------------|----------|----------|
+| `id`          | A unique identifier for the Magic UI component, as defined in the registry. | Yes      | –        |
+| `version`     | The version of Next.js to use when generating a new project.                | No       | `latest` |
+| `router`      | The router format to use (`app` or `page`).                                 | No       | `app`    |
+| `slotId`      | The variable name that holds the slot ID created or used by the template.   | Yes      | –        |
+| `slotVersion` | The variable name that holds the version of the slot.                       | Yes      | –        |
+| `components`  | A list of Magic UI component files to download and include in the project.  | No       | –        |
+| `extension`   | The URL of an extension template to apply.                                  | Yes      | -        |

--- a/templates/magic-ui/component/component/template.json5
+++ b/templates/magic-ui/component/component/template.json5
@@ -50,24 +50,13 @@
       ],
       "default": "app"
     },
-    "slotId": {
-      "type": "reference",
-      "description": "The variable name that holds the slot ID.",
-      "required": true
-    },
-    "slotVersion": {
-      "type": "reference",
-      "description": "The variable name that holds the slot version.",
-      "required": true
-    },
     "components": {
       "type": "array",
       "description": "The components to import."
     },
-    "action": {
-      "type": "object",
-      "description": "Additional actions to execute.",
-      "required": false
+    "extension": {
+      "type": "string",
+      "description": "The URL of the extension template to apply."
     }
   },
   "actions": [
@@ -123,7 +112,23 @@
         "examplePath": "${this.exampleDirectory}/${this.exampleFile}"
       }
     },
-    "${options.action}",
+    {
+      "name": "define",
+      "variables": {
+        "slotId": "",
+        "slotVersion": ""
+      }
+    },
+    {
+      "name": "import",
+      "template": "${options.extension}",
+      "options": {
+        "exampleDirectory": "${this.exampleDirectory}",
+        "exampleFile": "${this.exampleFile}",
+        "slotId": "slotId",
+        "slotVersion": "slotVersion"
+      }
+    },
     {
       "name": "define",
       "variables": {
@@ -155,7 +160,7 @@
     {
       "name": "add-slot",
       "slots": [
-        "${this[options.slotId]}@${this[options.slotVersion]}"
+        "${this.slotId}@${this.slotVersion}"
       ]
     },
     {
@@ -166,11 +171,11 @@
           "replacements": [
             {
               "pattern": "%slotId%",
-              "value": "${this[options.slotId]}"
+              "value": "${this.slotId}"
             },
             {
               "pattern": "%slotVersion%",
-              "value": "${this[options.slotVersion]}"
+              "value": "${this.slotVersion}"
             },
             {
               "pattern": "%workspaceUrl%",

--- a/templates/magic-ui/component/dock/configuration/dock-schema.json
+++ b/templates/magic-ui/component/dock/configuration/dock-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/template-content-schema.json",
   "type": "structure",
-  "title": "Magic UI - Dock",
+  "title": "Dock",
   "attributes": {
     "iconSize": {
       "type": {

--- a/templates/magic-ui/component/dock/extension.json5
+++ b/templates/magic-ui/component/dock/extension.json5
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Dock customization",
+  "description": "A customization template for the dock component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "import",
+      "template": "shadcn-ui://component",
+      "options": {
+        "components": [
+          "button",
+          "separator",
+          "tooltip"
+        ]
+      }
+    },
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-dock": {
+            "name": "Magic UI - Dock",
+            "description": "A list of avatars to represent people, brands, or tools.",
+            "schema": "${import('./configuration/dock-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-dock": {
+            "name": "Magic UI - Dock",
+            "component": "magic-ui-dock",
+            "content": {
+              "en": "${import('./configuration/dock-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-dock": {
+            "id": "slotId",
+            "version": "slotVersion"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/dock/template.json5
+++ b/templates/magic-ui/component/dock/template.json5
@@ -54,56 +54,10 @@
         "id": "dock",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "dock-menu.tsx"
         ],
-        "action": {
-          "name": "run",
-          "actions": [
-            {
-              "name": "import",
-              "template": "shadcn-ui://component",
-              "options": {
-                "components": [
-                  "button",
-                  "separator",
-                  "tooltip"
-                ]
-              }
-            },
-            {
-              "name": "create-resource",
-              "resources": {
-                "components": {
-                  "magic-ui-dock": {
-                    "name": "Magic UI - Dock",
-                    "description": "A list of avatars to represent people, brands, or tools.",
-                    "schema": "${import('./configuration/dock-schema.json')}"
-                  }
-                },
-                "slots": {
-                  "magic-ui-dock": {
-                    "name": "Magic UI - Dock",
-                    "component": "magic-ui-dock",
-                    "content": {
-                      "en": "${import('./configuration/dock-content.en.json')}"
-                    }
-                  }
-                }
-              },
-              "result": {
-                "slots": {
-                  "magic-ui-dock": {
-                    "id": "slotId",
-                    "version": "slotVersion"
-                  }
-                }
-              }
-            }
-          ]
-        }
+        "extension": "magic-ui://component/dock/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/dock/template.json5
+++ b/templates/magic-ui/component/dock/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Dock",
+  "title": "Dock",
   "description": "A list of avatars to represent people, brands, or tools.",
   "metadata": {
     "id": "library/magic-ui/dock",

--- a/templates/magic-ui/component/globe/configuration/globe-schema.json
+++ b/templates/magic-ui/component/globe/configuration/globe-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/template-content-schema.json",
   "type": "structure",
-  "title": "Magic UI - Animated list",
+  "title": "Animated list",
   "attributes": {
     "markers": {
       "type": {

--- a/templates/magic-ui/component/globe/extension.json5
+++ b/templates/magic-ui/component/globe/extension.json5
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Globe customization",
+  "description": "A customization template for the globe component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "add-dependency",
+      "dependencies": [
+        "motion"
+      ]
+    },
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-globe": {
+            "name": "Magic UI - Globe",
+            "description": "A 3D globe to visualize global presence, activity, or reach.",
+            "schema": "${import('./configuration/globe-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-globe": {
+            "name": "Magic UI - Globe",
+            "component": "magic-ui-globe",
+            "content": {
+              "en": "${import('./configuration/globe-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-globe": {
+            "id": "slotId",
+            "version": "slotVersion"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/globe/template.json5
+++ b/templates/magic-ui/component/globe/template.json5
@@ -54,51 +54,10 @@
         "id": "globe",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "global-presence.tsx"
         ],
-        "action": {
-          "name": "run",
-          "actions": [
-            {
-              "name": "add-dependency",
-              "dependencies": [
-                "motion"
-              ]
-            },
-            {
-              "name": "create-resource",
-              "resources": {
-                "components": {
-                  "magic-ui-globe": {
-                    "name": "Magic UI - Globe",
-                    "description": "A 3D globe to visualize global presence, activity, or reach.",
-                    "schema": "${import('./configuration/globe-schema.json')}"
-                  }
-                },
-                "slots": {
-                  "magic-ui-globe": {
-                    "name": "Magic UI - Globe",
-                    "component": "magic-ui-globe",
-                    "content": {
-                      "en": "${import('./configuration/globe-content.en.json')}"
-                    }
-                  }
-                }
-              },
-              "result": {
-                "slots": {
-                  "magic-ui-globe": {
-                    "id": "slotId",
-                    "version": "slotVersion"
-                  }
-                }
-              }
-            }
-          ]
-        }
+        "extension": "magic-ui://component/globe/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/globe/template.json5
+++ b/templates/magic-ui/component/globe/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Globe",
+  "title": "Globe",
   "description": "A 3D globe to visualize global presence, activity, or reach.",
   "metadata": {
     "id": "library/magic-ui/globe",

--- a/templates/magic-ui/component/hero-video-dialog/extension.json5
+++ b/templates/magic-ui/component/hero-video-dialog/extension.json5
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Hero video dialog customization",
+  "description": "A customization template for the hero video dialog component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-hero-video-dialog": {
+            "name": "Magic UI - Hero video dialog",
+            "description": "A hero section with a video dialog to introduce or demo your product.",
+            "schema": "${import('./configuration/hero-video-dialog-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-hero-video-dialog": {
+            "name": "Magic UI - Hero video dialog",
+            "component": "magic-ui-hero-video-dialog",
+            "content": {
+              "en": "${import('./configuration/hero-video-dialog-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-hero-video-dialog": {
+            "id": "slotId",
+            "version": "slotVersion"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/hero-video-dialog/template.json5
+++ b/templates/magic-ui/component/hero-video-dialog/template.json5
@@ -54,45 +54,10 @@
         "id": "hero-video-dialog",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "hero-video-player.tsx"
         ],
-        "action": {
-          "name": "run",
-          "actions": [
-            {
-              "name": "create-resource",
-              "resources": {
-                "components": {
-                  "magic-ui-hero-video-dialog": {
-                    "name": "Magic UI - Hero video dialog",
-                    "description": "A hero section with a video dialog to introduce or demo your product.",
-                    "schema": "${import('./configuration/hero-video-dialog-schema.json')}"
-                  }
-                },
-                "slots": {
-                  "magic-ui-hero-video-dialog": {
-                    "name": "Magic UI - Hero video dialog",
-                    "component": "magic-ui-hero-video-dialog",
-                    "content": {
-                      "en": "${import('./configuration/hero-video-dialog-content.en.json')}"
-                    }
-                  }
-                }
-              },
-              "result": {
-                "slots": {
-                  "magic-ui-hero-video-dialog": {
-                    "id": "slotId",
-                    "version": "slotVersion"
-                  }
-                }
-              }
-            }
-          ]
-        }
+        "extension": "magic-ui://component/hero-video-dialog/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/hero-video-dialog/template.json5
+++ b/templates/magic-ui/component/hero-video-dialog/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Hero video dialog",
+  "title": "Hero video dialog",
   "description": "A hero section with a video dialog to introduce or demo your product.",
   "metadata": {
     "id": "library/magic-ui/hero-video-dialog",

--- a/templates/magic-ui/component/icon-cloud/configuration/icon-cloud-schema.json
+++ b/templates/magic-ui/component/icon-cloud/configuration/icon-cloud-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/template-content-schema.json",
   "type": "structure",
-  "title": "Magic UI - Icon cloud",
+  "title": "Icon cloud",
   "attributes": {
     "images": {
       "type": {

--- a/templates/magic-ui/component/icon-cloud/extension.json5
+++ b/templates/magic-ui/component/icon-cloud/extension.json5
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Icon cloud customization",
+  "description": "A customization template for the icon cloud component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-icon-cloud": {
+            "name": "Magic UI - Icon cloud",
+            "description": "A floating cloud of icons to showcase integrations, tools, or technologies.",
+            "schema": "${import('./configuration/icon-cloud-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-icon-cloud": {
+            "name": "Magic UI - Icon cloud",
+            "component": "magic-ui-icon-cloud",
+            "content": {
+              "en": "${import('./configuration/icon-cloud-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-icon-cloud": {
+            "id": "slotId",
+            "version": "slotVersion"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/icon-cloud/template.json5
+++ b/templates/magic-ui/component/icon-cloud/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Icon cloud",
+  "title": "Icon cloud",
   "description": "A floating cloud of icons to showcase integrations, tools, or technologies.",
   "metadata": {
     "id": "library/magic-ui/icon-cloud",

--- a/templates/magic-ui/component/icon-cloud/template.json5
+++ b/templates/magic-ui/component/icon-cloud/template.json5
@@ -55,45 +55,10 @@
         "id": "icon-cloud",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "icon-cloud-demo.tsx"
         ],
-        "action": {
-          "name": "run",
-          "actions": [
-            {
-              "name": "create-resource",
-              "resources": {
-                "components": {
-                  "magic-ui-icon-cloud": {
-                    "name": "Magic UI - Icon cloud",
-                    "description": "A floating cloud of icons to showcase integrations, tools, or technologies.",
-                    "schema": "${import('./configuration/icon-cloud-schema.json')}"
-                  }
-                },
-                "slots": {
-                  "magic-ui-icon-cloud": {
-                    "name": "Magic UI - Icon cloud",
-                    "component": "magic-ui-icon-cloud",
-                    "content": {
-                      "en": "${import('./configuration/icon-cloud-content.en.json')}"
-                    }
-                  }
-                }
-              },
-              "result": {
-                "slots": {
-                  "magic-ui-icon-cloud": {
-                    "id": "slotId",
-                    "version": "slotVersion"
-                  }
-                }
-              }
-            }
-          ]
-        }
+        "extension": "magic-ui://component/icon-cloud/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/lens/configuration/lens-schema.json
+++ b/templates/magic-ui/component/lens/configuration/lens-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/template-content-schema.json",
   "type": "structure",
-  "title": "Magic UI - Lens",
+  "title": "Lens",
   "attributes": {
     "image": {
       "type": {

--- a/templates/magic-ui/component/lens/extension.json5
+++ b/templates/magic-ui/component/lens/extension.json5
@@ -1,0 +1,68 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Lens customization",
+  "description": "A customization template for the lens component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "import",
+      "template": "shadcn-ui://component",
+      "options": {
+        "components": [
+          "button",
+          "card"
+        ]
+      }
+    },
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-lens": {
+            "name": "Magic UI - Lens",
+            "description": "A hover effect that highlights or magnifies content within a section.",
+            "schema": "${import('./configuration/lens-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-lens": {
+            "name": "Magic UI - Lens",
+            "component": "magic-ui-lens",
+            "content": {
+              "en": "${import('./configuration/lens-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-lens": {
+            "id": "slotId",
+            "version": "slotVersion"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/lens/template.json5
+++ b/templates/magic-ui/component/lens/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Lens",
+  "title": "Lens",
   "description": "A hover effect that highlights or magnifies content within a section.",
   "metadata": {
     "id": "library/magic-ui/lens",

--- a/templates/magic-ui/component/lens/template.json5
+++ b/templates/magic-ui/component/lens/template.json5
@@ -51,55 +51,10 @@
         "id": "lens",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "lens-card.tsx"
         ],
-        "action": {
-          "name": "run",
-          "actions": [
-            {
-              "name": "import",
-              "template": "shadcn-ui://component",
-              "options": {
-                "components": [
-                  "button",
-                  "card"
-                ]
-              }
-            },
-            {
-              "name": "create-resource",
-              "resources": {
-                "components": {
-                  "magic-ui-lens": {
-                    "name": "Magic UI - Lens",
-                    "description": "A hover effect that highlights or magnifies content within a section.",
-                    "schema": "${import('./configuration/lens-schema.json')}"
-                  }
-                },
-                "slots": {
-                  "magic-ui-lens": {
-                    "name": "Magic UI - Lens",
-                    "component": "magic-ui-lens",
-                    "content": {
-                      "en": "${import('./configuration/lens-content.en.json')}"
-                    }
-                  }
-                }
-              },
-              "result": {
-                "slots": {
-                  "magic-ui-lens": {
-                    "id": "slotId",
-                    "version": "slotVersion"
-                  }
-                }
-              }
-            }
-          ]
-        }
+        "extension": "magic-ui://component/lens/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/marquee/configuration/marquee-schema.json
+++ b/templates/magic-ui/component/marquee/configuration/marquee-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/template-content-schema.json",
   "type": "structure",
-  "title": "Magic UI - Marquee Reviews",
+  "title": "Marquee Reviews",
   "attributes": {
     "reviews": {
       "type": {

--- a/templates/magic-ui/component/marquee/extension.json5
+++ b/templates/magic-ui/component/marquee/extension.json5
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Marquee customization",
+  "description": "A customization template for the marquee component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-marquee-reviews": {
+            "name": "Magic UI - Marquee reviews",
+            "description": "An infinite scrolling component for displaying testimonials, or user reviews.",
+            "schema": "${import('./configuration/marquee-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-marquee-reviews": {
+            "name": "Magic UI - Marquee reviews",
+            "component": "magic-ui-marquee-reviews",
+            "content": {
+              "en": "${import('./configuration/marquee-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-marquee-reviews": {
+            "id": "slotId",
+            "version": "slotVersion"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/marquee/template.json5
+++ b/templates/magic-ui/component/marquee/template.json5
@@ -59,41 +59,11 @@
         "id": "marquee",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "review-card.tsx",
           "review-list.tsx"
         ],
-        "action": {
-          "name": "create-resource",
-          "resources": {
-            "components": {
-              "magic-ui-marquee-reviews": {
-                "name": "Magic UI - Marquee reviews",
-                "description": "An infinite scrolling component for displaying testimonials, or user reviews.",
-                "schema": "${import('./configuration/marquee-schema.json')}"
-              }
-            },
-            "slots": {
-              "magic-ui-marquee-reviews": {
-                "name": "Magic UI - Marquee reviews",
-                "component": "magic-ui-marquee-reviews",
-                "content": {
-                  "en": "${import('./configuration/marquee-content.en.json')}"
-                }
-              }
-            }
-          },
-          "result": {
-            "slots": {
-              "magic-ui-marquee-reviews": {
-                "id": "slotId",
-                "version": "slotVersion"
-              }
-            }
-          }
-        }
+        "extension": "magic-ui://component/marquee/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/marquee/template.json5
+++ b/templates/magic-ui/component/marquee/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Marquee",
+  "title": "Marquee",
   "description": "An infinite scrolling component for displaying testimonials, or user reviews.",
   "metadata": {
     "id": "library/magic-ui/marquee",

--- a/templates/magic-ui/component/orbiting-circles/configuration/orbiting-circles-schema.json
+++ b/templates/magic-ui/component/orbiting-circles/configuration/orbiting-circles-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/template-content-schema.json",
   "type": "structure",
-  "title": "Magic UI - Orbiting circles",
+  "title": "Orbiting circles",
   "attributes": {
     "orbits": {
       "type": {

--- a/templates/magic-ui/component/orbiting-circles/extension.json5
+++ b/templates/magic-ui/component/orbiting-circles/extension.json5
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Orbiting circles customization",
+  "description": "A customization template for the orbiting circles component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-orbiting-circles": {
+            "name": "Magic UI - Orbiting circles",
+            "description": "Animated circles orbiting a central element to represent relationships or connections.",
+            "schema": "${import('./configuration/orbiting-circles-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-orbiting-circles": {
+            "name": "Magic UI - Orbiting circles",
+            "component": "magic-ui-orbiting-circles",
+            "content": {
+              "en": "${import('./configuration/orbiting-circles-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-orbiting-circles": {
+            "id": "slotId",
+            "version": "slotVersion"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/orbiting-circles/template.json5
+++ b/templates/magic-ui/component/orbiting-circles/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Orbiting circles",
+  "title": "Orbiting circles",
   "description": "Animated circles orbiting a central element to represent relationships or connections.",
   "metadata": {
     "id": "library/magic-ui/orbiting-circles",

--- a/templates/magic-ui/component/orbiting-circles/template.json5
+++ b/templates/magic-ui/component/orbiting-circles/template.json5
@@ -57,45 +57,10 @@
         "id": "orbiting-circles",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "orbiting-icons.tsx"
         ],
-        "action": {
-          "name": "run",
-          "actions": [
-            {
-              "name": "create-resource",
-              "resources": {
-                "components": {
-                  "magic-ui-orbiting-circles": {
-                    "name": "Magic UI - Orbiting circles",
-                    "description": "Animated circles orbiting a central element to represent relationships or connections.",
-                    "schema": "${import('./configuration/orbiting-circles-schema.json')}"
-                  }
-                },
-                "slots": {
-                  "magic-ui-orbiting-circles": {
-                    "name": "Magic UI - Orbiting circles",
-                    "component": "magic-ui-orbiting-circles",
-                    "content": {
-                      "en": "${import('./configuration/orbiting-circles-content.en.json')}"
-                    }
-                  }
-                }
-              },
-              "result": {
-                "slots": {
-                  "magic-ui-orbiting-circles": {
-                    "id": "slotId",
-                    "version": "slotVersion"
-                  }
-                }
-              }
-            }
-          ]
-        }
+        "extension": "magic-ui://component/orbiting-circles/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/script-copy-btn/configuration/script-copy-btn-schema.json
+++ b/templates/magic-ui/component/script-copy-btn/configuration/script-copy-btn-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/template-content-schema.json",
   "type": "structure",
-  "title": "Magic UI - Script copy button",
+  "title": "Script copy button",
   "attributes": {
     "codeLanguage": {
       "type": {

--- a/templates/magic-ui/component/script-copy-btn/extension.json5
+++ b/templates/magic-ui/component/script-copy-btn/extension.json5
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Script copy button customization",
+  "description": "A customization template for the script copy button component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-script-copy-btn": {
+            "name": "Magic UI - Script copy button",
+            "description": "A button for quickly copying scripts, commands, or code snippets.",
+            "schema": "${import('./configuration/script-copy-btn-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-script-copy-btn": {
+            "name": "Magic UI - Script copy button",
+            "component": "magic-ui-script-copy-btn",
+            "content": {
+              "en": "${import('./configuration/script-copy-btn-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-script-copy-btn": {
+            "id": "slotId",
+            "version": "slotVersion"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/script-copy-btn/template.json5
+++ b/templates/magic-ui/component/script-copy-btn/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Script copy button",
+  "title": "Script copy button",
   "description": "A button for quickly copying scripts, commands, or code snippets.",
   "metadata": {
     "id": "library/magic-ui/script-copy-btn",

--- a/templates/magic-ui/component/script-copy-btn/template.json5
+++ b/templates/magic-ui/component/script-copy-btn/template.json5
@@ -57,45 +57,10 @@
         "id": "script-copy-btn",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "copy-command-block.tsx"
         ],
-        "action": {
-          "name": "run",
-          "actions": [
-            {
-              "name": "create-resource",
-              "resources": {
-                "components": {
-                  "magic-ui-script-copy-btn": {
-                    "name": "Magic UI - Script copy button",
-                    "description": "A button for quickly copying scripts, commands, or code snippets.",
-                    "schema": "${import('./configuration/script-copy-btn-schema.json')}"
-                  }
-                },
-                "slots": {
-                  "magic-ui-script-copy-btn": {
-                    "name": "Magic UI - Script copy button",
-                    "component": "magic-ui-script-copy-btn",
-                    "content": {
-                      "en": "${import('./configuration/script-copy-btn-content.en.json')}"
-                    }
-                  }
-                }
-              },
-              "result": {
-                "slots": {
-                  "magic-ui-script-copy-btn": {
-                    "id": "slotId",
-                    "version": "slotVersion"
-                  }
-                }
-              }
-            }
-          ]
-        }
+        "extension": "magic-ui://component/script-copy-btn/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/terminal/configuration/terminal-schema.json
+++ b/templates/magic-ui/component/terminal/configuration/terminal-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/template-content-schema.json",
   "type": "structure",
-  "title": "Magic UI - Terminal",
+  "title": "Terminal",
   "attributes": {
     "output": {
       "label": "Output",

--- a/templates/magic-ui/component/terminal/extension.json5
+++ b/templates/magic-ui/component/terminal/extension.json5
@@ -1,0 +1,64 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Terminal customization",
+  "description": "A customization template for the terminal component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "add-dependency",
+      "dependencies": [
+        "motion"
+      ]
+    },
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-terminal": {
+            "name": "Magic UI - Terminal",
+            "description": "A terminal-style UI to showcase commands, output, or interactive code.",
+            "schema": "${import('./configuration/terminal-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-terminal": {
+            "name": "Magic UI - Terminal",
+            "component": "magic-ui-terminal",
+            "content": {
+              "en": "${import('./configuration/terminal-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-terminal": {
+            "id": "slotId",
+            "version": "slotVersion"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/terminal/template.json5
+++ b/templates/magic-ui/component/terminal/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Terminal",
+  "title": "Terminal",
   "description": "A terminal-style UI to showcase commands, output, or interactive code.",
   "metadata": {
     "id": "library/magic-ui/terminal",

--- a/templates/magic-ui/component/terminal/template.json5
+++ b/templates/magic-ui/component/terminal/template.json5
@@ -58,51 +58,10 @@
         "id": "terminal",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "cli-demo.tsx"
         ],
-        "action": {
-          "name": "run",
-          "actions": [
-            {
-              "name": "add-dependency",
-              "dependencies": [
-                "motion"
-              ]
-            },
-            {
-              "name": "create-resource",
-              "resources": {
-                "components": {
-                  "magic-ui-terminal": {
-                    "name": "Magic UI - Terminal",
-                    "description": "A terminal-style UI to showcase commands, output, or interactive code.",
-                    "schema": "${import('./configuration/terminal-schema.json')}"
-                  }
-                },
-                "slots": {
-                  "magic-ui-terminal": {
-                    "name": "Magic UI - Terminal",
-                    "component": "magic-ui-terminal",
-                    "content": {
-                      "en": "${import('./configuration/terminal-content.en.json')}"
-                    }
-                  }
-                }
-              },
-              "result": {
-                "slots": {
-                  "magic-ui-terminal": {
-                    "id": "slotId",
-                    "version": "slotVersion"
-                  }
-                }
-              }
-            }
-          ]
-        }
+        "extension": "magic-ui://component/terminal/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/tweet-card/configuration/tweet-card-schema.json
+++ b/templates/magic-ui/component/tweet-card/configuration/tweet-card-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.croct.com/json/v1/template-content-schema.json",
   "type": "structure",
-  "title": "Magic UI - Tweet card",
+  "title": "Tweet card",
   "attributes": {
     "id": {
       "type": {

--- a/templates/magic-ui/component/tweet-card/extension.json5
+++ b/templates/magic-ui/component/tweet-card/extension.json5
@@ -1,0 +1,58 @@
+{
+  "$schema": "https://schema.croct.com/json/v1/template.json",
+  "title": "Tweet card customization",
+  "description": "A customization template for the tweet card component.",
+  "options": {
+    "slotId": {
+      "type": "reference",
+      "description": "The variable name that holds the slot ID.",
+      "required": true
+    },
+    "slotVersion": {
+      "type": "reference",
+      "description": "The variable name that holds the slot version.",
+      "required": true
+    },
+    "exampleDirectory": {
+      "type": "string",
+      "description": "The path to the example directory.",
+      "required": true
+    },
+    "exampleFile": {
+      "type": "string",
+      "description": "The name of the example file.",
+      "required": true
+    },
+  },
+  "actions": [
+    {
+      "name": "create-resource",
+      "resources": {
+        "components": {
+          "magic-ui-tweet-card": {
+            "name": "Magic UI - Tweet card",
+            "description": "A styled tweet embed to highlight social proof or share updates.",
+            "schema": "${import('./configuration/tweet-card-schema.json')}"
+          }
+        },
+        "slots": {
+          "magic-ui-tweet-card": {
+            "name": "Magic UI - Tweet card",
+            "component": "magic-ui-tweet-card",
+            "content": {
+              "en": "${import('./configuration/tweet-card-content.en.json')}"
+            }
+          }
+        }
+      },
+      "result": {
+        "slots": {
+          "magic-ui-tweet-card": {
+            "id": "slotId",
+            "version": "slotVersion"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/templates/magic-ui/component/tweet-card/template.json5
+++ b/templates/magic-ui/component/tweet-card/template.json5
@@ -69,45 +69,10 @@
         "id": "tweet-card",
         "version": "${options.version}",
         "router": "${options.router}",
-        "slotId": "slotId",
-        "slotVersion": "slotVersion",
         "components": [
           "${options.rsc ? 'server' : 'client'}/tweet.tsx"
         ],
-        "action": {
-          "name": "run",
-          "actions": [
-            {
-              "name": "create-resource",
-              "resources": {
-                "components": {
-                  "magic-ui-tweet-card": {
-                    "name": "Magic UI - Tweet card",
-                    "description": "A styled tweet embed to highlight social proof or share updates.",
-                    "schema": "${import('./configuration/tweet-card-schema.json')}"
-                  }
-                },
-                "slots": {
-                  "magic-ui-tweet-card": {
-                    "name": "Magic UI - Tweet card",
-                    "component": "magic-ui-tweet-card",
-                    "content": {
-                      "en": "${import('./configuration/tweet-card-content.en.json')}"
-                    }
-                  }
-                }
-              },
-              "result": {
-                "slots": {
-                  "magic-ui-tweet-card": {
-                    "id": "slotId",
-                    "version": "slotVersion"
-                  }
-                }
-              }
-            }
-          ]
-        }
+        "extension": "magic-ui://component/tweet-card/extension.json5"
       }
     }
   ]

--- a/templates/magic-ui/component/tweet-card/template.json5
+++ b/templates/magic-ui/component/tweet-card/template.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.croct.com/json/v1/catalog-template.json",
-  "title": "Magic UI - Tweet card",
+  "title": "Tweet card",
   "description": "A styled tweet embed to highlight social proof or share updates.",
   "metadata": {
     "id": "library/magic-ui/tweet-card",


### PR DESCRIPTION
## Summary
We previously allowed passing *actions* to customize templates. While flexible, this approach had two major drawbacks:

* Lack of access to information that exists only within the template
* No schema validation for the customization logic

To address this, we've adopted a new approach: passing another template dedicated to customization. This ensures better encapsulation, access to contextual data, and schema enforcement.

This PR refactors Magic UI to use this new customization template pattern.

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings