### PR TITLE
Fix Mantine broken templates

### DIFF
--- a/templates/mantine/block/features-title/code/components/FeaturesTitle/index.tsx
+++ b/templates/mantine/block/features-title/code/components/FeaturesTitle/index.tsx
@@ -40,12 +40,13 @@ export function FeaturesTitle(props: FeaturesTitleProps) {
           )}
           
           <Button
+            component="a"
             variant="gradient"
             gradient={{ deg: 133, from: 'blue', to: 'cyan' }}
             size="lg"
             radius="md"
             mt="xl"
-            herf={cta.link}
+            href={cta.link}
           >
             {cta.label}
           </Button>

--- a/templates/mantine/block/hero-content-left/code/components/HeroContentLeft/index.tsx
+++ b/templates/mantine/block/hero-content-left/code/components/HeroContentLeft/index.tsx
@@ -37,7 +37,13 @@ export function HeroContentLeft(props: HeroContentLeftProps) {
             })}
         </Text>
 
-        <Button variant="gradient" size="xl" radius="xl" className={classes.control} href={cta.link}>
+        <Button 
+          variant="gradient" 
+          component="a"
+          size="xl" 
+          radius="xl" 
+          className={classes.control} 
+          href={cta.link}>
           {cta.label}
         </Button>
       </Container>

--- a/templates/mantine/component/carousel-card/code/components/CarouselCard/index.tsx
+++ b/templates/mantine/component/carousel-card/code/components/CarouselCard/index.tsx
@@ -76,7 +76,13 @@ export function CarouselCard(props: CarouselCardProps) {
           </Text>
         </div>
 
-        <Button radius="md" href={cta.link}>{cta.label}</Button>
+        <Button
+          component="a" 
+          radius="md" 
+          href={cta.link}
+        >
+          {cta.label}
+        </Button>
       </Group>
     </Card>
   );

--- a/templates/mantine/component/image-action-banner/code/components/ImageActionBanner/index.tsx
+++ b/templates/mantine/component/image-action-banner/code/components/ImageActionBanner/index.tsx
@@ -36,7 +36,13 @@ export function ImageActionBanner(props: ImageActionBannerProps) {
             })}
         </Text>
 
-        <Button className={classes.action} variant="white" color="dark" size="xs" href={cta.link}>
+        <Button 
+          component="a"
+          className={classes.action} 
+          variant="white" 
+          color="dark" 
+          size="xs" 
+          href={cta.link}>
           {cta.label}
         </Button>
       </div>


### PR DESCRIPTION
## Summary
Fix broken templates.

Templates adjusted:

- Hero section with content on left
- Banner with image and action
- Card with carousel
- Features section with title

### Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings