### PR TITLE
Add Strapi integration work around

### DIFF
--- a/templates/croct/integration/strapi/template.json5
+++ b/templates/croct/integration/strapi/template.json5
@@ -52,7 +52,7 @@
       "name": "execute-package",
       "command": "giget@latest",
       "arguments": [
-        "gh:strapi/LaunchPad",
+        "gh:strapi/LaunchPad#8ccb412934020a02c903f0aadfc0decff644d333",
         "${this.projectName}"
       ]
     },
@@ -118,6 +118,12 @@
       "name": "install"
     },
     {
+      "name": "add-dependency",
+      "dependencies": [
+        "@strapi/types@5.19.0"
+      ]
+    },
+    {
       "name": "execute-package",
       "command": "seed",
       "script": true,
@@ -128,6 +134,13 @@
     {
       "name": "change-directory",
       "path": "../next"
+    },
+    {
+      "name": "add-dependency",
+      "development": true,
+      "dependencies": [
+        "husky"
+      ]
     },
     {
       "name": "add-dependency",


### PR DESCRIPTION
## Summary
This PR implements a workaround to handle a Strapi issue.

### Problem
Currently, we internally use the [strapi/LaunchPad](https://github.com/strapi/LaunchPad) CLI to provide Strapi integration. When running the command `seed`, the following error occurs:
```
src/middlewares/deepPopulate.ts:23:33 - error TS2345: Argument of type src/middlewares/deepPopulate.ts:23:33 - error TS2345: Argument of type
│  'import(".../project/strapi/nodemodules/@strapi/types/dist/uid/index").Schema' is not assignable to parameter of type
│  'import(".../project/strapi/nodemodules/@strapi/core/node_modules/@strapi/types/dist/uid/index").Schema'.
```
### Work around
The error is caused by a mismatch between the `@strapi/type` package version in the dependencies root and inside the `@strapi/core` module. To work around that, a step installing the same specific version from `@strapi/core` on the root was added. An additional care is to set the LaunchPad version specifying the current commit hash, so any update will not break the implementation again.

### Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings