### PR TITLE
Fix missing md-lite dependency and Sanity template instructions

### DIFF
--- a/templates/croct/integration/sanity/template.json5
+++ b/templates/croct/integration/sanity/template.json5
@@ -269,6 +269,7 @@
     {
       "name": "add-dependency",
       "dependencies": [
+        "@croct/md-lite",
         "@croct/template-ui"
       ]
     },
@@ -463,12 +464,10 @@
       "name": "install"
     },
     {
-      "name": "import",
-      "template": "croct:/utils/example-launcher",
-      "options": {
-        "script": "dev",
-        "url": "http://localhost:3000"
-      }
+      "name": "print",
+      "semantics": "success",
+      "title": "Your project is ready",
+      "message": "To start the development server, run:\n\n`cd ${this.projectName} && npm run dev`\n\nThe command output shows the URLs of the website and the Sanity Studio."
     }
   ]
 }

--- a/templates/croct/ui/component/announcement-bar/template.json5
+++ b/templates/croct/ui/component/announcement-bar/template.json5
@@ -109,6 +109,7 @@
     {
       "name": "add-dependency",
       "dependencies": [
+        "@croct/md-lite",
         "@croct/template-ui",
         "lucide-react"
       ]

--- a/templates/hero-ui/component/cookie-consent/template.json5
+++ b/templates/hero-ui/component/cookie-consent/template.json5
@@ -56,6 +56,12 @@
   },
   "actions": [
     {
+      "name": "add-dependency",
+      "dependencies": [
+        "@croct/md-lite"
+      ]
+    },
+    {
       "name": "import",
       "template": "hero-ui://component/component",
       "options": {

--- a/templates/material-ui/block/faq-section/template.json5
+++ b/templates/material-ui/block/faq-section/template.json5
@@ -65,6 +65,7 @@
         "router": "${options.router}",
         "javascript": "${options.javascript}",
         "dependencies": [
+          "@croct/md-lite",
           "@mui/icons-material"
         ],
         "components": [

--- a/templates/material-ui/block/hero-section/template.json5
+++ b/templates/material-ui/block/hero-section/template.json5
@@ -67,6 +67,9 @@
         "version": "${options.version}",
         "router": "${options.router}",
         "javascript": "${options.javascript}",
+        "dependencies": [
+          "@croct/md-lite"
+        ],
         "components": [
           "HeroSection.tsx",
           "HeroDemo.tsx"

--- a/templates/material-ui/template/marketing-page/template.json5
+++ b/templates/material-ui/template/marketing-page/template.json5
@@ -169,6 +169,7 @@
         "router": "${options.router}",
         "javascript": "${options.javascript}",
         "dependencies": [
+          "@croct/md-lite",
           "@mui/icons-material"
         ],
         "components": [


### PR DESCRIPTION
## Summary

- Add the missing `@croct/md-lite` dependency to all templates that install a `markdown.tsx` utility importing it: `croct/integration/sanity`, `croct/ui/component/announcement-bar`, `hero-ui/component/cookie-consent`, `material-ui/block/faq-section`, `material-ui/block/hero-section`, and `material-ui/template/marketing-page`. Fresh installs of these templates failed with `Module not found: Can't resolve '@croct/md-lite'` — no published Croct package pulls it in transitively, so it only resolved by accident when an ancestor `node_modules` contained it (the mantine templates already declare it correctly).
- Replace the Sanity template's `example-launcher` import with an explicit success message telling the user to run `cd <project> && npm run dev`, since the Sanity CLI cannot be launched from the template. The message points to the command output for URLs instead of hardcoding them, as ports may be assigned dynamically.

## Test plan

- [x] All edited `template.json5` files validate as JSON5
- [ ] Run `croct use croct://integration/sanity` in an empty directory and confirm `@croct/md-lite` lands in `frontend/package.json` and `npm run dev` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)